### PR TITLE
[#153321792] Clean up ElastiCache parameter groups for deprovisioned Redis instances

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -162,7 +162,8 @@ func (b *Broker) Unbind(ctx context.Context, instanceID, bindingID string, detai
 // LastOperation returns with the last known state of the given service instance
 func (b *Broker) LastOperation(ctx context.Context, instanceID, operationData string) (brokerapi.LastOperation, error) {
 	b.logger.Debug("last-operation", lager.Data{
-		"instance-id": instanceID,
+		"instance-id":    instanceID,
+		"operation-data": operationData,
 	})
 
 	providerCtx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)

--- a/broker/mocks/provider.go
+++ b/broker/mocks/provider.go
@@ -51,20 +51,6 @@ type FakeProvider struct {
 		result2 string
 		result3 error
 	}
-	GetCredentialsForInstanceStub        func(ctx context.Context, instanceID string) (interface{}, error)
-	getCredentialsForInstanceMutex       sync.RWMutex
-	getCredentialsForInstanceArgsForCall []struct {
-		ctx        context.Context
-		instanceID string
-	}
-	getCredentialsForInstanceReturns struct {
-		result1 interface{}
-		result2 error
-	}
-	getCredentialsForInstanceReturnsOnCall map[int]struct {
-		result1 interface{}
-		result2 error
-	}
 	GenerateCredentialsStub        func(ctx context.Context, instanceID, bindingID string) (*broker.Credentials, error)
 	generateCredentialsMutex       sync.RWMutex
 	generateCredentialsArgsForCall []struct {
@@ -91,6 +77,18 @@ type FakeProvider struct {
 		result1 error
 	}
 	revokeCredentialsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeleteCacheParameterGroupStub        func(ctx context.Context, instanceID string) error
+	deleteCacheParameterGroupMutex       sync.RWMutex
+	deleteCacheParameterGroupArgsForCall []struct {
+		ctx        context.Context
+		instanceID string
+	}
+	deleteCacheParameterGroupReturns struct {
+		result1 error
+	}
+	deleteCacheParameterGroupReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -252,58 +250,6 @@ func (fake *FakeProvider) GetStateReturnsOnCall(i int, result1 broker.ServiceSta
 	}{result1, result2, result3}
 }
 
-func (fake *FakeProvider) GetCredentialsForInstance(ctx context.Context, instanceID string) (interface{}, error) {
-	fake.getCredentialsForInstanceMutex.Lock()
-	ret, specificReturn := fake.getCredentialsForInstanceReturnsOnCall[len(fake.getCredentialsForInstanceArgsForCall)]
-	fake.getCredentialsForInstanceArgsForCall = append(fake.getCredentialsForInstanceArgsForCall, struct {
-		ctx        context.Context
-		instanceID string
-	}{ctx, instanceID})
-	fake.recordInvocation("GetCredentialsForInstance", []interface{}{ctx, instanceID})
-	fake.getCredentialsForInstanceMutex.Unlock()
-	if fake.GetCredentialsForInstanceStub != nil {
-		return fake.GetCredentialsForInstanceStub(ctx, instanceID)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getCredentialsForInstanceReturns.result1, fake.getCredentialsForInstanceReturns.result2
-}
-
-func (fake *FakeProvider) GetCredentialsForInstanceCallCount() int {
-	fake.getCredentialsForInstanceMutex.RLock()
-	defer fake.getCredentialsForInstanceMutex.RUnlock()
-	return len(fake.getCredentialsForInstanceArgsForCall)
-}
-
-func (fake *FakeProvider) GetCredentialsForInstanceArgsForCall(i int) (context.Context, string) {
-	fake.getCredentialsForInstanceMutex.RLock()
-	defer fake.getCredentialsForInstanceMutex.RUnlock()
-	return fake.getCredentialsForInstanceArgsForCall[i].ctx, fake.getCredentialsForInstanceArgsForCall[i].instanceID
-}
-
-func (fake *FakeProvider) GetCredentialsForInstanceReturns(result1 interface{}, result2 error) {
-	fake.GetCredentialsForInstanceStub = nil
-	fake.getCredentialsForInstanceReturns = struct {
-		result1 interface{}
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeProvider) GetCredentialsForInstanceReturnsOnCall(i int, result1 interface{}, result2 error) {
-	fake.GetCredentialsForInstanceStub = nil
-	if fake.getCredentialsForInstanceReturnsOnCall == nil {
-		fake.getCredentialsForInstanceReturnsOnCall = make(map[int]struct {
-			result1 interface{}
-			result2 error
-		})
-	}
-	fake.getCredentialsForInstanceReturnsOnCall[i] = struct {
-		result1 interface{}
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeProvider) GenerateCredentials(ctx context.Context, instanceID string, bindingID string) (*broker.Credentials, error) {
 	fake.generateCredentialsMutex.Lock()
 	ret, specificReturn := fake.generateCredentialsReturnsOnCall[len(fake.generateCredentialsArgsForCall)]
@@ -407,6 +353,55 @@ func (fake *FakeProvider) RevokeCredentialsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeProvider) DeleteCacheParameterGroup(ctx context.Context, instanceID string) error {
+	fake.deleteCacheParameterGroupMutex.Lock()
+	ret, specificReturn := fake.deleteCacheParameterGroupReturnsOnCall[len(fake.deleteCacheParameterGroupArgsForCall)]
+	fake.deleteCacheParameterGroupArgsForCall = append(fake.deleteCacheParameterGroupArgsForCall, struct {
+		ctx        context.Context
+		instanceID string
+	}{ctx, instanceID})
+	fake.recordInvocation("DeleteCacheParameterGroup", []interface{}{ctx, instanceID})
+	fake.deleteCacheParameterGroupMutex.Unlock()
+	if fake.DeleteCacheParameterGroupStub != nil {
+		return fake.DeleteCacheParameterGroupStub(ctx, instanceID)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.deleteCacheParameterGroupReturns.result1
+}
+
+func (fake *FakeProvider) DeleteCacheParameterGroupCallCount() int {
+	fake.deleteCacheParameterGroupMutex.RLock()
+	defer fake.deleteCacheParameterGroupMutex.RUnlock()
+	return len(fake.deleteCacheParameterGroupArgsForCall)
+}
+
+func (fake *FakeProvider) DeleteCacheParameterGroupArgsForCall(i int) (context.Context, string) {
+	fake.deleteCacheParameterGroupMutex.RLock()
+	defer fake.deleteCacheParameterGroupMutex.RUnlock()
+	return fake.deleteCacheParameterGroupArgsForCall[i].ctx, fake.deleteCacheParameterGroupArgsForCall[i].instanceID
+}
+
+func (fake *FakeProvider) DeleteCacheParameterGroupReturns(result1 error) {
+	fake.DeleteCacheParameterGroupStub = nil
+	fake.deleteCacheParameterGroupReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeProvider) DeleteCacheParameterGroupReturnsOnCall(i int, result1 error) {
+	fake.DeleteCacheParameterGroupStub = nil
+	if fake.deleteCacheParameterGroupReturnsOnCall == nil {
+		fake.deleteCacheParameterGroupReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteCacheParameterGroupReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeProvider) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -416,12 +411,12 @@ func (fake *FakeProvider) Invocations() map[string][][]interface{} {
 	defer fake.deprovisionMutex.RUnlock()
 	fake.getStateMutex.RLock()
 	defer fake.getStateMutex.RUnlock()
-	fake.getCredentialsForInstanceMutex.RLock()
-	defer fake.getCredentialsForInstanceMutex.RUnlock()
 	fake.generateCredentialsMutex.RLock()
 	defer fake.generateCredentialsMutex.RUnlock()
 	fake.revokeCredentialsMutex.RLock()
 	defer fake.revokeCredentialsMutex.RUnlock()
+	fake.deleteCacheParameterGroupMutex.RLock()
+	defer fake.deleteCacheParameterGroupMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/broker/provider.go
+++ b/broker/provider.go
@@ -25,6 +25,7 @@ type Provider interface {
 	GetState(ctx context.Context, instanceID string) (ServiceState, string, error)
 	GenerateCredentials(ctx context.Context, instanceID, bindingID string) (*Credentials, error)
 	RevokeCredentials(ctx context.Context, instanceID, bindingID string) error
+	DeleteCacheParameterGroup(ctx context.Context, instanceID string) error
 }
 
 // Credentials are the connection parameters for Redis clients

--- a/redis/provider.go
+++ b/redis/provider.go
@@ -59,6 +59,21 @@ func (p *Provider) createCacheParameterGroup(ctx context.Context, instanceID str
 	return err
 }
 
+func (p *Provider) DeleteCacheParameterGroup(ctx context.Context, instanceID string) error {
+	replicationGroupID := GenerateReplicationGroupName(instanceID)
+	_, err := p.aws.DeleteCacheParameterGroupWithContext(ctx, &elasticache.DeleteCacheParameterGroupInput{
+		CacheParameterGroupName: aws.String(replicationGroupID),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == elasticache.ErrCodeCacheParameterGroupNotFoundFault {
+				return nil
+			}
+		}
+	}
+	return err
+}
+
 // Provision creates a replication group and a cache parameter group
 func (p *Provider) Provision(ctx context.Context, instanceID string, params broker.ProvisionParameters) error {
 	replicationGroupID := GenerateReplicationGroupName(instanceID)

--- a/redis/provider_test.go
+++ b/redis/provider_test.go
@@ -439,6 +439,37 @@ var _ = Describe("Provider", func() {
 
 	})
 
+	Context("when deleting a parameter group", func() {
+		It("should delete the parameter group successfully", func() {
+			ctx := context.Background()
+			err := provider.DeleteCacheParameterGroup(ctx, "foobar")
+
+			Expect(mockElasticache.DeleteCacheParameterGroupWithContextCallCount()).To(Equal(1))
+			receivedCtx, receivedInput, _ := mockElasticache.DeleteCacheParameterGroupWithContextArgsForCall(0)
+			Expect(receivedCtx).To(Equal(ctx))
+			Expect(receivedInput).To(Equal(&elasticache.DeleteCacheParameterGroupInput{
+				CacheParameterGroupName: aws.String("cf-qwkec4pxhft6q"),
+			}))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return no error if parameter group does not exist", func() {
+			deleteErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "some message", nil)
+			mockElasticache.DeleteCacheParameterGroupWithContextReturns(nil, deleteErr)
+			err := provider.DeleteCacheParameterGroup(context.Background(), "foobar")
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return an error if deleting the parameter group fails", func() {
+			deleteErr := errors.New("A really really really bad error")
+			mockElasticache.DeleteCacheParameterGroupWithContextReturns(nil, deleteErr)
+			err := provider.DeleteCacheParameterGroup(context.Background(), "foobar")
+
+			Expect(err).To(MatchError(deleteErr))
+		})
+	})
+
 	Context("when revoking credentials from an app", func() {
 		It("should return no error", func() {
 			instanceID := "foobar"


### PR DESCRIPTION
## What

Delete cache parameter group after the replication group was deleted.

We can create only a limited number of cache parameter groups on AWS therefore we have to clean up the ones we don't need anymore. Also we don't want to leave unnecessary resources in our AWS accounts.
The cache parameter group can not be deleted while the replication group still exists and the deletion usually takes a long time. We decided to do the clean up in the last operation API call.

We return with operation specific data in the provision/deprovision/update calls so we can identify the last action in the last operation API call (CF will pass back this operation data to the broker). The operation data is JSON so we can extend it easily in the future if necessary.

If deleting the cache parameter group fails CF will keep calling the last operation endpoint until it succeeds (until we return no error in the last operation response).

## How to review

Test as part of https://github.com/alphagov/paas-cf/pull/1134

## Who can review

Not @LeePorte or @bandesz
