### PR TITLE
[WIP] Configure CacheParameterGroup from plan config

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The password will be the same for all bindings as the ElastiCache Redis replicat
         "elasticache:DescribeReplicationGroups",
         "elasticache:DeleteReplicationGroup",
         "elasticache:CreateCacheParameterGroup",
+        "elasticache:DescribeCacheParameterGroups",
         "elasticache:ModifyCacheParameterGroup",
         "elasticache:DeleteCacheParameterGroup"
       ],

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -69,7 +69,7 @@ func (b *Broker) Provision(ctx context.Context, instanceID string, details broke
 
 	provisionParams := ProvisionParameters{
 		InstanceType:               planConfig.InstanceType,
-		CacheParameterGroupName:    "default.redis3.2",
+		CacheParameterGroupName:    planConfig.CacheParameterGroupName,
 		SecurityGroupIds:           b.config.VpcSecurityGroupIds,
 		CacheSubnetGroupName:       b.config.CacheSubnetGroupName,
 		PreferredMaintenanceWindow: "sun:23:00-mon:01:30",
@@ -212,12 +212,6 @@ func (b *Broker) LastOperation(ctx context.Context, instanceID, operationData st
 	}
 
 	if state == NonExisting {
-		if operation.Action == ActionDeprovisioning {
-			err = b.provider.DeleteCacheParameterGroup(providerCtx, instanceID)
-			if err != nil {
-				return brokerapi.LastOperation{}, fmt.Errorf("error deleting parameter group %s: %s", instanceID, err)
-			}
-		}
 		return brokerapi.LastOperation{}, brokerapi.ErrInstanceDoesNotExist
 	}
 

--- a/broker/config.go
+++ b/broker/config.go
@@ -43,6 +43,7 @@ type PlanConfig struct {
 	ShardCount               int64             `json:"shard_count"`
 	SnapshotRetentionLimit   int64             `json:"snapshot_retention_limit"`
 	AutomaticFailoverEnabled bool              `json:"automatic_failover_enabled"`
+	CacheParameterGroupName  string            `json:"cache_parameter_group_name"`
 	Parameters               map[string]string `json:"parameters"`
 }
 

--- a/broker/mocks/provider.go
+++ b/broker/mocks/provider.go
@@ -79,18 +79,6 @@ type FakeProvider struct {
 	revokeCredentialsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DeleteCacheParameterGroupStub        func(ctx context.Context, instanceID string) error
-	deleteCacheParameterGroupMutex       sync.RWMutex
-	deleteCacheParameterGroupArgsForCall []struct {
-		ctx        context.Context
-		instanceID string
-	}
-	deleteCacheParameterGroupReturns struct {
-		result1 error
-	}
-	deleteCacheParameterGroupReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -353,55 +341,6 @@ func (fake *FakeProvider) RevokeCredentialsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeProvider) DeleteCacheParameterGroup(ctx context.Context, instanceID string) error {
-	fake.deleteCacheParameterGroupMutex.Lock()
-	ret, specificReturn := fake.deleteCacheParameterGroupReturnsOnCall[len(fake.deleteCacheParameterGroupArgsForCall)]
-	fake.deleteCacheParameterGroupArgsForCall = append(fake.deleteCacheParameterGroupArgsForCall, struct {
-		ctx        context.Context
-		instanceID string
-	}{ctx, instanceID})
-	fake.recordInvocation("DeleteCacheParameterGroup", []interface{}{ctx, instanceID})
-	fake.deleteCacheParameterGroupMutex.Unlock()
-	if fake.DeleteCacheParameterGroupStub != nil {
-		return fake.DeleteCacheParameterGroupStub(ctx, instanceID)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.deleteCacheParameterGroupReturns.result1
-}
-
-func (fake *FakeProvider) DeleteCacheParameterGroupCallCount() int {
-	fake.deleteCacheParameterGroupMutex.RLock()
-	defer fake.deleteCacheParameterGroupMutex.RUnlock()
-	return len(fake.deleteCacheParameterGroupArgsForCall)
-}
-
-func (fake *FakeProvider) DeleteCacheParameterGroupArgsForCall(i int) (context.Context, string) {
-	fake.deleteCacheParameterGroupMutex.RLock()
-	defer fake.deleteCacheParameterGroupMutex.RUnlock()
-	return fake.deleteCacheParameterGroupArgsForCall[i].ctx, fake.deleteCacheParameterGroupArgsForCall[i].instanceID
-}
-
-func (fake *FakeProvider) DeleteCacheParameterGroupReturns(result1 error) {
-	fake.DeleteCacheParameterGroupStub = nil
-	fake.deleteCacheParameterGroupReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeProvider) DeleteCacheParameterGroupReturnsOnCall(i int, result1 error) {
-	fake.DeleteCacheParameterGroupStub = nil
-	if fake.deleteCacheParameterGroupReturnsOnCall == nil {
-		fake.deleteCacheParameterGroupReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.deleteCacheParameterGroupReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeProvider) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -415,8 +354,6 @@ func (fake *FakeProvider) Invocations() map[string][][]interface{} {
 	defer fake.generateCredentialsMutex.RUnlock()
 	fake.revokeCredentialsMutex.RLock()
 	defer fake.revokeCredentialsMutex.RUnlock()
-	fake.deleteCacheParameterGroupMutex.RLock()
-	defer fake.deleteCacheParameterGroupMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/broker/provider.go
+++ b/broker/provider.go
@@ -25,7 +25,6 @@ type Provider interface {
 	GetState(ctx context.Context, instanceID string) (ServiceState, string, error)
 	GenerateCredentials(ctx context.Context, instanceID, bindingID string) (*Credentials, error)
 	RevokeCredentials(ctx context.Context, instanceID, bindingID string) error
-	DeleteCacheParameterGroup(ctx context.Context, instanceID string) error
 }
 
 // Credentials are the connection parameters for Redis clients

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -18,8 +18,20 @@
 				"plans": [
 					{
 						"id": "94767b71-2b9c-4960-a4f8-77b81a96f7e0",
-						"name": "micro",
-						"description": "Micro plan",
+						"name": "micro-volatile-ttl",
+						"description": "Micro plan with volatile-ttl eviction policy",
+						"free": false
+					},
+					{
+						"id": "94767b71-2b9c-4960-a4f8-77b81a96f7e1",
+						"name": "micro-allkeys-random",
+						"description": "Micro plan with allkeys-random eviction policy",
+						"free": false
+					},
+					{
+						"id": "94767b71-2b9c-4960-a4f8-77b81a96f7e2",
+						"name": "micro-allkeys-lru",
+						"description": "Micro plan with allkeys-lru eviction policy",
 						"free": false
 					}
 				]
@@ -34,8 +46,33 @@
 			"shard_count": 1,
 			"snapshot_retention_limit": 0,
 			"automatic_failover_enabled": false,
+			"cache_parameter_group_name": "micro-volatile-ttl",
 			"parameters": {
-				"maxmemory-policy": "volatile-lru",
+				"maxmemory-policy": "volatile-ttl",
+				"reserved-memory": "0"
+			}
+		},
+		"94767b71-2b9c-4960-a4f8-77b81a96f7e1": {
+			"instance_type": "cache.t2.micro",
+			"replicas_per_node_group": 0,
+			"shard_count": 1,
+			"snapshot_retention_limit": 0,
+			"automatic_failover_enabled": false,
+			"cache_parameter_group_name": "micro-allkeys-random",
+			"parameters": {
+				"maxmemory-policy": "allkeys-random",
+				"reserved-memory": "0"
+			}
+		},
+		"94767b71-2b9c-4960-a4f8-77b81a96f7e2": {
+			"instance_type": "cache.t2.micro",
+			"replicas_per_node_group": 0,
+			"shard_count": 1,
+			"snapshot_retention_limit": 0,
+			"automatic_failover_enabled": false,
+			"cache_parameter_group_name": "micro-allkeys-lru",
+			"parameters": {
+				"maxmemory-policy": "allkeys-lru",
 				"reserved-memory": "0"
 			}
 		}

--- a/redis/elasticache.go
+++ b/redis/elasticache.go
@@ -16,4 +16,5 @@ type ElastiCache interface {
 	DeleteReplicationGroupWithContext(ctx aws.Context, input *elasticache.DeleteReplicationGroupInput, opts ...request.Option) (*elasticache.DeleteReplicationGroupOutput, error)
 	DescribeReplicationGroupsWithContext(ctx aws.Context, input *elasticache.DescribeReplicationGroupsInput, opts ...request.Option) (*elasticache.DescribeReplicationGroupsOutput, error)
 	ModifyCacheParameterGroupWithContext(ctx aws.Context, input *elasticache.ModifyCacheParameterGroupInput, opts ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error)
+	DescribeCacheParameterGroupsWithContext(ctx aws.Context, input *elasticache.DescribeCacheParameterGroupsInput, opts ...request.Option) (*elasticache.DescribeCacheParameterGroupsOutput, error)
 }

--- a/redis/mocks/elasticache.go
+++ b/redis/mocks/elasticache.go
@@ -101,6 +101,21 @@ type FakeElastiCache struct {
 		result1 *elasticache.CacheParameterGroupNameMessage
 		result2 error
 	}
+	DescribeCacheParameterGroupsWithContextStub        func(ctx aws.Context, input *elasticache.DescribeCacheParameterGroupsInput, opts ...request.Option) (*elasticache.DescribeCacheParameterGroupsOutput, error)
+	describeCacheParameterGroupsWithContextMutex       sync.RWMutex
+	describeCacheParameterGroupsWithContextArgsForCall []struct {
+		ctx   aws.Context
+		input *elasticache.DescribeCacheParameterGroupsInput
+		opts  []request.Option
+	}
+	describeCacheParameterGroupsWithContextReturns struct {
+		result1 *elasticache.DescribeCacheParameterGroupsOutput
+		result2 error
+	}
+	describeCacheParameterGroupsWithContextReturnsOnCall map[int]struct {
+		result1 *elasticache.DescribeCacheParameterGroupsOutput
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -423,6 +438,59 @@ func (fake *FakeElastiCache) ModifyCacheParameterGroupWithContextReturnsOnCall(i
 	}{result1, result2}
 }
 
+func (fake *FakeElastiCache) DescribeCacheParameterGroupsWithContext(ctx aws.Context, input *elasticache.DescribeCacheParameterGroupsInput, opts ...request.Option) (*elasticache.DescribeCacheParameterGroupsOutput, error) {
+	fake.describeCacheParameterGroupsWithContextMutex.Lock()
+	ret, specificReturn := fake.describeCacheParameterGroupsWithContextReturnsOnCall[len(fake.describeCacheParameterGroupsWithContextArgsForCall)]
+	fake.describeCacheParameterGroupsWithContextArgsForCall = append(fake.describeCacheParameterGroupsWithContextArgsForCall, struct {
+		ctx   aws.Context
+		input *elasticache.DescribeCacheParameterGroupsInput
+		opts  []request.Option
+	}{ctx, input, opts})
+	fake.recordInvocation("DescribeCacheParameterGroupsWithContext", []interface{}{ctx, input, opts})
+	fake.describeCacheParameterGroupsWithContextMutex.Unlock()
+	if fake.DescribeCacheParameterGroupsWithContextStub != nil {
+		return fake.DescribeCacheParameterGroupsWithContextStub(ctx, input, opts...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.describeCacheParameterGroupsWithContextReturns.result1, fake.describeCacheParameterGroupsWithContextReturns.result2
+}
+
+func (fake *FakeElastiCache) DescribeCacheParameterGroupsWithContextCallCount() int {
+	fake.describeCacheParameterGroupsWithContextMutex.RLock()
+	defer fake.describeCacheParameterGroupsWithContextMutex.RUnlock()
+	return len(fake.describeCacheParameterGroupsWithContextArgsForCall)
+}
+
+func (fake *FakeElastiCache) DescribeCacheParameterGroupsWithContextArgsForCall(i int) (aws.Context, *elasticache.DescribeCacheParameterGroupsInput, []request.Option) {
+	fake.describeCacheParameterGroupsWithContextMutex.RLock()
+	defer fake.describeCacheParameterGroupsWithContextMutex.RUnlock()
+	return fake.describeCacheParameterGroupsWithContextArgsForCall[i].ctx, fake.describeCacheParameterGroupsWithContextArgsForCall[i].input, fake.describeCacheParameterGroupsWithContextArgsForCall[i].opts
+}
+
+func (fake *FakeElastiCache) DescribeCacheParameterGroupsWithContextReturns(result1 *elasticache.DescribeCacheParameterGroupsOutput, result2 error) {
+	fake.DescribeCacheParameterGroupsWithContextStub = nil
+	fake.describeCacheParameterGroupsWithContextReturns = struct {
+		result1 *elasticache.DescribeCacheParameterGroupsOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) DescribeCacheParameterGroupsWithContextReturnsOnCall(i int, result1 *elasticache.DescribeCacheParameterGroupsOutput, result2 error) {
+	fake.DescribeCacheParameterGroupsWithContextStub = nil
+	if fake.describeCacheParameterGroupsWithContextReturnsOnCall == nil {
+		fake.describeCacheParameterGroupsWithContextReturnsOnCall = make(map[int]struct {
+			result1 *elasticache.DescribeCacheParameterGroupsOutput
+			result2 error
+		})
+	}
+	fake.describeCacheParameterGroupsWithContextReturnsOnCall[i] = struct {
+		result1 *elasticache.DescribeCacheParameterGroupsOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeElastiCache) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -438,6 +506,8 @@ func (fake *FakeElastiCache) Invocations() map[string][][]interface{} {
 	defer fake.describeReplicationGroupsWithContextMutex.RUnlock()
 	fake.modifyCacheParameterGroupWithContextMutex.RLock()
 	defer fake.modifyCacheParameterGroupWithContextMutex.RUnlock()
+	fake.describeCacheParameterGroupsWithContextMutex.RLock()
+	defer fake.describeCacheParameterGroupsWithContextMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/redis/provider_test.go
+++ b/redis/provider_test.go
@@ -38,7 +38,8 @@ var _ = Describe("Provider", func() {
 			ctx := context.Background()
 
 			describeErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "cache parameter group not found", nil)
-			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(0, nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(1, nil, nil)
 
 			err := provider.Provision(ctx, instanceID, broker.ProvisionParameters{
 				CacheParameterGroupName: "micro-volatile-lru",
@@ -49,7 +50,7 @@ var _ = Describe("Provider", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(mockElasticache.DescribeCacheParameterGroupsWithContextCallCount()).To(Equal(1))
+			Expect(mockElasticache.DescribeCacheParameterGroupsWithContextCallCount()).To(Equal(2))
 			Expect(mockElasticache.CreateCacheParameterGroupWithContextCallCount()).To(Equal(1))
 			receivedCtx, receivedInput, _ := mockElasticache.CreateCacheParameterGroupWithContextArgsForCall(0)
 			Expect(receivedCtx).To(Equal(ctx))
@@ -101,7 +102,7 @@ var _ = Describe("Provider", func() {
 
 		It("handles errors during checking for parameter group existance", func() {
 			describeErr := errors.New("err while describing")
-			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(0, nil, describeErr)
 
 			provisionErr := provider.Provision(context.Background(), "foobar", broker.ProvisionParameters{})
 			Expect(provisionErr).To(MatchError(describeErr))
@@ -112,7 +113,8 @@ var _ = Describe("Provider", func() {
 
 		It("handles errors during parameter group creation", func() {
 			describeErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "cache parameter group not found", nil)
-			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(0, nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(1, nil, nil)
 
 			createErr := errors.New("some error")
 			mockElasticache.CreateCacheParameterGroupWithContextReturnsOnCall(0, nil, createErr)
@@ -126,7 +128,8 @@ var _ = Describe("Provider", func() {
 
 		It("handles errors during parameter group update", func() {
 			describeErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "cache parameter group not found", nil)
-			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(0, nil, describeErr)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturnsOnCall(1, nil, nil)
 
 			modifyErr := errors.New("some error")
 			mockElasticache.ModifyCacheParameterGroupWithContextReturnsOnCall(0, nil, modifyErr)

--- a/redis/provider_test.go
+++ b/redis/provider_test.go
@@ -31,25 +31,31 @@ var _ = Describe("Provider", func() {
 	})
 
 	Context("when provisioning", func() {
-		It("creates a cache parameter group and sets the parameters", func() {
+		It("creates a cache parameter group and sets the parameters if missing", func() {
 			replicationGroupID := "cf-qwkec4pxhft6q"
 			instanceID := "foobar"
 
 			ctx := context.Background()
 
-			provider.Provision(ctx, instanceID, broker.ProvisionParameters{
+			describeErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "cache parameter group not found", nil)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+
+			err := provider.Provision(ctx, instanceID, broker.ProvisionParameters{
+				CacheParameterGroupName: "micro-volatile-lru",
 				Parameters: map[string]string{
 					"key1": "value1",
 					"key2": "value2",
 				},
 			})
+			Expect(err).ToNot(HaveOccurred())
 
+			Expect(mockElasticache.DescribeCacheParameterGroupsWithContextCallCount()).To(Equal(1))
 			Expect(mockElasticache.CreateCacheParameterGroupWithContextCallCount()).To(Equal(1))
 			receivedCtx, receivedInput, _ := mockElasticache.CreateCacheParameterGroupWithContextArgsForCall(0)
 			Expect(receivedCtx).To(Equal(ctx))
 			Expect(receivedInput).To(Equal(&elasticache.CreateCacheParameterGroupInput{
 				CacheParameterGroupFamily: aws.String("redis3.2"),
-				CacheParameterGroupName:   aws.String(replicationGroupID),
+				CacheParameterGroupName:   aws.String("micro-volatile-lru"),
 				Description:               aws.String("Created by Cloud Foundry"),
 			}))
 
@@ -69,7 +75,45 @@ var _ = Describe("Provider", func() {
 			}))
 		})
 
+		It("does not create a cache parameter group when it already exists", func() {
+			instanceID := "foobar"
+
+			ctx := context.Background()
+
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(&elasticache.DescribeCacheParameterGroupsOutput{
+				CacheParameterGroups: []*elasticache.CacheParameterGroup{
+					{},
+				},
+			}, nil)
+
+			err := provider.Provision(ctx, instanceID, broker.ProvisionParameters{
+				CacheParameterGroupName: "micro-volatile-lru",
+				Parameters: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockElasticache.DescribeCacheParameterGroupsWithContextCallCount()).To(Equal(1))
+			Expect(mockElasticache.CreateCacheParameterGroupWithContextCallCount()).To(Equal(0))
+			Expect(mockElasticache.ModifyCacheParameterGroupWithContextCallCount()).To(Equal(0))
+		})
+
+		It("handles errors during checking for parameter group existance", func() {
+			describeErr := errors.New("err while describing")
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+
+			provisionErr := provider.Provision(context.Background(), "foobar", broker.ProvisionParameters{})
+			Expect(provisionErr).To(MatchError(describeErr))
+
+			Expect(mockElasticache.ModifyCacheParameterGroupWithContextCallCount()).To(Equal(0))
+			Expect(mockElasticache.CreateReplicationGroupWithContextCallCount()).To(Equal(0))
+		})
+
 		It("handles errors during parameter group creation", func() {
+			describeErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "cache parameter group not found", nil)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+
 			createErr := errors.New("some error")
 			mockElasticache.CreateCacheParameterGroupWithContextReturnsOnCall(0, nil, createErr)
 
@@ -81,6 +125,9 @@ var _ = Describe("Provider", func() {
 		})
 
 		It("handles errors during parameter group update", func() {
+			describeErr := awserr.New(elasticache.ErrCodeCacheParameterGroupNotFoundFault, "cache parameter group not found", nil)
+			mockElasticache.DescribeCacheParameterGroupsWithContextReturns(nil, describeErr)
+
 			modifyErr := errors.New("some error")
 			mockElasticache.ModifyCacheParameterGroupWithContextReturnsOnCall(0, nil, modifyErr)
 
@@ -92,12 +139,11 @@ var _ = Describe("Provider", func() {
 		})
 
 		It("creates the replication group", func() {
-			replicationGroupID := "cf-qwkec4pxhft6q"
 			ctx := context.Background()
 			instanceID := "foobar"
 			params := broker.ProvisionParameters{
 				InstanceType:               "test instance type",
-				CacheParameterGroupName:    replicationGroupID,
+				CacheParameterGroupName:    "test-param-group-1",
 				SecurityGroupIds:           []string{"test sg1"},
 				CacheSubnetGroupName:       "test subnet group",
 				PreferredMaintenanceWindow: "test maintenance window",
@@ -122,14 +168,14 @@ var _ = Describe("Provider", func() {
 				AuthToken:                   aws.String("Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4="),
 				AutomaticFailoverEnabled:    aws.Bool(true),
 				CacheNodeType:               aws.String("test instance type"),
-				CacheParameterGroupName:     aws.String(replicationGroupID),
+				CacheParameterGroupName:     aws.String("test-param-group-1"),
 				SecurityGroupIds:            aws.StringSlice([]string{"test sg1"}),
 				CacheSubnetGroupName:        aws.String("test subnet group"),
 				Engine:                      aws.String("redis"),
 				EngineVersion:               aws.String("3.2.6"),
 				PreferredMaintenanceWindow:  aws.String("test maintenance window"),
 				ReplicationGroupDescription: aws.String("test desc"),
-				ReplicationGroupId:          aws.String(replicationGroupID),
+				ReplicationGroupId:          aws.String("cf-qwkec4pxhft6q"),
 				NumNodeGroups:               aws.Int64(1),
 				NumCacheClusters:            aws.Int64(3),
 			}))


### PR DESCRIPTION
# ⚠️ WIP ⚠️ 

## What

Previously we had one elasticache parameter group per instance. This was
because there are several useful configuration options that tenants may
have wanted to set to tune the behaviour of their elasticache instance.

Unfortunatly AWS is quite strict with the number of unique
CacheParameterGroups and does not give us a way to easily know when we
were hitting the limits.

To work around this limit we have decided to have one parameter group
per PLAN so that we can more easily predict the number of parameter
groups required. The downside to this is that important parameters
(suchas the memory eviction policy for redis) must now be configured at
plan-level so a larger number of plans are required to support the
various configurations that tenants may require.

This change requires that a `CacheParameterGroupName` be set in the
`PlanConfig` and that name will be used to create a parameter group if
it does not exist.

## How to review

* Code review
* Ensure tests are sane and pass

## Who can review

Not @chrisfarms or @46bit 