### PR TITLE
[#154956796] Add maxmemory policy

### DIFF
--- a/broker/api_test.go
+++ b/broker/api_test.go
@@ -3,7 +3,6 @@ package broker_test
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -118,35 +117,6 @@ var _ = Describe("Broker", func() {
 			))
 
 			Expect(resp.Code).To(Equal(202))
-		})
-
-		It("responds with an error if parameters contain an unknown key", func() {
-			instanceID := uuid.NewV4().String()
-			resp := DoRequest(brokerAPI, NewRequest(
-				"PUT",
-				"/v2/service_instances/"+instanceID,
-				strings.NewReader(`{
-					"service_id": "service1",
-					"plan_id": "plan1",
-					"organization_guid": "test-organization-id",
-					"space_guid": "space-id",
-					"parameters": {
-						"unknown_key": "foo"
-					}
-				}`),
-				credentials.Username,
-				credentials.Password,
-				url.Values{"accepts_incomplete": []string{"true"}},
-			))
-
-			Expect(resp.Code).To(Equal(500))
-			body, err := ioutil.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(body)).To(MatchJSON(`
-			{
-			  "description": "unknown parameter: unknown_key"
-			}
-			`))
 		})
 
 		It("responds with a 500 when an unknown provisioning error occurs", func() {

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -89,6 +89,7 @@ func (b *Broker) Provision(ctx context.Context, instanceID string, details broke
 		}
 	}
 
+	// TODO: parsing the user provided parameters should be done in the provider and not in the broker
 	var restoreFromSnapshotName *string
 	if userParameters.RestoreFromLatestSnapshotOf != nil {
 		snapshots, err := b.provider.FindSnapshots(providerCtx, *userParameters.RestoreFromLatestSnapshotOf)

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -219,7 +219,7 @@ func (b *Broker) Update(ctx context.Context, instanceID string, details brokerap
 		"accepts-incomplete": asyncAllowed,
 	})
 	return brokerapi.UpdateServiceSpec{
-		IsAsync:       false,
+		IsAsync:       true,
 		OperationData: Operation{Action: ActionUpdating}.String(),
 	}, nil
 }

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -432,7 +432,7 @@ var _ = Describe("Broker", func() {
 			Expect(params).To(Equal(expectedParameters))
 
 			Expect(spec).To(Equal(brokerapi.UpdateServiceSpec{
-				IsAsync:       false,
+				IsAsync:       true,
 				OperationData: broker.Operation{Action: broker.ActionUpdating}.String(),
 			}))
 		})

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Broker", func() {
 			fakeProvider := &mocks.FakeProvider{}
 			b := broker.New(validConfig, fakeProvider, lager.NewLogger("logger"))
 
-			validProvisionDetails.RawParameters = []byte(`{"maxmemory-policy": "noeviction"}`)
+			validProvisionDetails.RawParameters = []byte(`{"maxmemory_policy": "noeviction"}`)
 
 			_, err := b.Provision(context.Background(), "instanceid", validProvisionDetails, true)
 			Expect(err).ToNot(HaveOccurred())

--- a/broker/config.go
+++ b/broker/config.go
@@ -14,8 +14,6 @@ var (
 	ErrNoSuchPlan = errors.New("no plan found")
 )
 
-type UpdateParameters struct{}
-
 type BindParameters struct{}
 
 type PlanConfig struct {

--- a/broker/parameters.go
+++ b/broker/parameters.go
@@ -11,7 +11,7 @@ func ParseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 	if err != nil {
 		return nil, err
 	}
-	validKeys := []string{"restore_from_latest_snapshot_of"}
+	validKeys := []string{"restore_from_latest_snapshot_of", "maxmemory-policy"}
 	for key := range mapParams {
 		valid := false
 		for _, validKey := range validKeys {
@@ -33,4 +33,5 @@ func ParseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 
 type ProvisionParameters struct {
 	RestoreFromLatestSnapshotOf *string `json:"restore_from_latest_snapshot_of"`
+	MaxMemoryPolicy             *string `json:"maxmemory-policy"`
 }

--- a/broker/parameters.go
+++ b/broker/parameters.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 )
 
+const ParamRestoreLatestSnapshotOf = "restore_from_latest_snapshot_of"
+const ParamMaxMemoryPolicy = "maxmemory_policy"
+
 func ParseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 	mapParams := map[string]interface{}{}
 	err := json.Unmarshal(data, &mapParams)
 	if err != nil {
 		return nil, err
 	}
-	validKeys := []string{"restore_from_latest_snapshot_of", "maxmemory-policy"}
+	validKeys := []string{ParamRestoreLatestSnapshotOf, ParamMaxMemoryPolicy}
 	for key := range mapParams {
 		valid := false
 		for _, validKey := range validKeys {
@@ -33,5 +36,5 @@ func ParseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 
 type ProvisionParameters struct {
 	RestoreFromLatestSnapshotOf *string `json:"restore_from_latest_snapshot_of"`
-	MaxMemoryPolicy             *string `json:"maxmemory-policy"`
+	MaxMemoryPolicy             *string `json:"maxmemory_policy"`
 }

--- a/broker/parameters.go
+++ b/broker/parameters.go
@@ -8,13 +8,35 @@ import (
 const ParamRestoreLatestSnapshotOf = "restore_from_latest_snapshot_of"
 const ParamMaxMemoryPolicy = "maxmemory_policy"
 
-func ParseProvisionParameters(data []byte) (*ProvisionParameters, error) {
-	mapParams := map[string]interface{}{}
-	err := json.Unmarshal(data, &mapParams)
+func parseProvisionParameters(data []byte) (*ProvisionParameters, error) {
+	params := &ProvisionParameters{}
+	err := unmarshalParameters(data, params, []string{
+		ParamRestoreLatestSnapshotOf,
+		ParamMaxMemoryPolicy,
+	})
 	if err != nil {
 		return nil, err
 	}
-	validKeys := []string{ParamRestoreLatestSnapshotOf, ParamMaxMemoryPolicy}
+	return params, nil
+}
+
+func parseUpdateParameters(data []byte) (*UpdateParameters, error) {
+	params := &UpdateParameters{}
+	err := unmarshalParameters(data, params, []string{
+		ParamMaxMemoryPolicy,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+func unmarshalParameters(data []byte, out interface{}, validKeys []string) error {
+	mapParams := map[string]interface{}{}
+	err := json.Unmarshal(data, &mapParams)
+	if err != nil {
+		return err
+	}
 	for key := range mapParams {
 		valid := false
 		for _, validKey := range validKeys {
@@ -24,17 +46,17 @@ func ParseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 			}
 		}
 		if !valid {
-			return nil, fmt.Errorf("unknown parameter: %s", key)
+			return fmt.Errorf("unknown parameter: %s", key)
 		}
 	}
-	provisionParameters := &ProvisionParameters{}
-	if err := json.Unmarshal(data, provisionParameters); err != nil {
-		return nil, err
-	}
-	return provisionParameters, nil
+	return json.Unmarshal(data, out)
 }
 
 type ProvisionParameters struct {
 	RestoreFromLatestSnapshotOf *string `json:"restore_from_latest_snapshot_of"`
 	MaxMemoryPolicy             *string `json:"maxmemory_policy"`
+}
+
+type UpdateParameters struct {
+	MaxMemoryPolicy *string `json:"maxmemory_policy"`
 }

--- a/ci/blackbox/elasticachebroker_test.go
+++ b/ci/blackbox/elasticachebroker_test.go
@@ -138,7 +138,7 @@ var _ = Describe("ElastiCache Broker Daemon", func() {
 				oldServiceID := serviceID
 				code, _, err := brokerAPIClient.UpdateInstance(instanceID, serviceID, planID, oldPlanID, oldServiceID, brokerAPIClient.DefaultOrganizationID, brokerAPIClient.DefaultSpaceID, updateParams)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(code).To(Equal(200))
+				Expect(code).To(Equal(202))
 			})
 
 			By("checking that the cache parameter group has been updated", func() {

--- a/ci/blackbox/elasticachebroker_test.go
+++ b/ci/blackbox/elasticachebroker_test.go
@@ -112,6 +112,51 @@ var _ = Describe("ElastiCache Broker Daemon", func() {
 				))
 			})
 
+			By("checking that the cache parameter group has been set", func() {
+				replicationGroupID := redis.GenerateReplicationGroupName(instanceID)
+				res, err := elasticacheService.DescribeCacheParameters(&elasticache.DescribeCacheParametersInput{
+					CacheParameterGroupName: aws.String(replicationGroupID),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				found := 0
+				for _, p := range res.Parameters {
+					if *p.ParameterName == "maxmemory-policy" {
+						found++
+						Expect(*p.ParameterValue).To(Equal("volatile-lru"))
+					}
+					if *p.ParameterName == "reserved-memory" {
+						found++
+						Expect(*p.ParameterValue).To(Equal("0"))
+					}
+				}
+				Expect(found).To(Equal(2))
+			})
+
+			By("updating parameters", func() {
+				updateParams := fmt.Sprintf(`{"maxmemory_policy": "noeviction"}`)
+				oldPlanID := planID
+				oldServiceID := serviceID
+				code, _, err := brokerAPIClient.UpdateInstance(instanceID, serviceID, planID, oldPlanID, oldServiceID, brokerAPIClient.DefaultOrganizationID, brokerAPIClient.DefaultSpaceID, updateParams)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(code).To(Equal(200))
+			})
+
+			By("checking that the cache parameter group has been updated", func() {
+				replicationGroupID := redis.GenerateReplicationGroupName(instanceID)
+				res, err := elasticacheService.DescribeCacheParameters(&elasticache.DescribeCacheParametersInput{
+					CacheParameterGroupName: aws.String(replicationGroupID),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				found := 0
+				for _, p := range res.Parameters {
+					if *p.ParameterName == "maxmemory-policy" {
+						found++
+						Expect(*p.ParameterValue).To(Equal("noeviction"))
+					}
+				}
+				Expect(found).To(Equal(1))
+			})
+
 			By("binding a resource to the service", func() {
 				code, bindingResponse, err := brokerAPIClient.Bind(instanceID, serviceID, planID, appID, bindingID)
 				Expect(err).ToNot(HaveOccurred())

--- a/ci/helpers/brokerapi_helper.go
+++ b/ci/helpers/brokerapi_helper.go
@@ -142,7 +142,7 @@ func (b *BrokerAPIClient) DoDeprovisionRequest(instanceID, serviceID, planID str
 	)
 }
 
-func (b *BrokerAPIClient) DoUpdateRequest(instanceID, serviceID, planID string, newPlanID string, paramJSON string) (*http.Response, error) {
+func (b *BrokerAPIClient) DoUpdateRequest(instanceID, serviceID, planID, oldPlanID, oldServiceID, orgID, spaceID, paramJSON string) (*http.Response, error) {
 	path := fmt.Sprintf("/v2/service_instances/%s", instanceID)
 
 	provisionDetailsJSON := []byte(fmt.Sprintf(`
@@ -150,11 +150,14 @@ func (b *BrokerAPIClient) DoUpdateRequest(instanceID, serviceID, planID string, 
 			"service_id": "%s",
 			"plan_id": "%s",
 			"previous_values": {
-				"plan_id": "%s"
+				"plan_id": "%s",
+				"service_id": "%s",
+				"org_id": "%s",
+				"space_id": "%s"
 			},
 			"parameters": %s
 		}
-	`, serviceID, planID, newPlanID, paramJSON))
+	`, serviceID, planID, oldPlanID, oldServiceID, orgID, spaceID, paramJSON))
 
 	return b.doRequest(
 		"PATCH",
@@ -212,8 +215,8 @@ func (b *BrokerAPIClient) DeprovisionInstance(instanceID, serviceID, planID stri
 	return resp.StatusCode, provisioningResponse.Operation, nil
 }
 
-func (b *BrokerAPIClient) UpdateInstance(instanceID, serviceID, planID string, newPlanID string, paramJSON string) (responseCode int, operation string, err error) {
-	resp, err := b.DoUpdateRequest(instanceID, serviceID, planID, newPlanID, paramJSON)
+func (b *BrokerAPIClient) UpdateInstance(instanceID, serviceID, planID, oldPlanID, oldServiceID, orgID, spaceID, paramJSON string) (responseCode int, operation string, err error) {
+	resp, err := b.DoUpdateRequest(instanceID, serviceID, planID, oldPlanID, oldServiceID, orgID, spaceID, paramJSON)
 	if err != nil {
 		return 0, "", err
 	}

--- a/providers/elasticache.go
+++ b/providers/elasticache.go
@@ -15,6 +15,8 @@ type ElastiCache interface {
 	DeleteCacheParameterGroupWithContext(ctx aws.Context, input *elasticache.DeleteCacheParameterGroupInput, opts ...request.Option) (*elasticache.DeleteCacheParameterGroupOutput, error)
 	DeleteReplicationGroupWithContext(ctx aws.Context, input *elasticache.DeleteReplicationGroupInput, opts ...request.Option) (*elasticache.DeleteReplicationGroupOutput, error)
 	DescribeReplicationGroupsWithContext(ctx aws.Context, input *elasticache.DescribeReplicationGroupsInput, opts ...request.Option) (*elasticache.DescribeReplicationGroupsOutput, error)
+	DescribeCacheClustersWithContext(ctx aws.Context, input *elasticache.DescribeCacheClustersInput, opts ...request.Option) (*elasticache.DescribeCacheClustersOutput, error)
+	DescribeCacheParametersWithContext(ctx aws.Context, input *elasticache.DescribeCacheParametersInput, opts ...request.Option) (*elasticache.DescribeCacheParametersOutput, error)
 	ModifyCacheParameterGroupWithContext(ctx aws.Context, input *elasticache.ModifyCacheParameterGroupInput, opts ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error)
 	DescribeSnapshotsPagesWithContext(ctx aws.Context, input *elasticache.DescribeSnapshotsInput, fn func(*elasticache.DescribeSnapshotsOutput, bool) bool, opts ...request.Option) error
 	ListTagsForResourceWithContext(ctx aws.Context, input *elasticache.ListTagsForResourceInput, opts ...request.Option) (*elasticache.TagListMessage, error)

--- a/providers/mocks/elasticache.go
+++ b/providers/mocks/elasticache.go
@@ -86,6 +86,36 @@ type FakeElastiCache struct {
 		result1 *elasticache.DescribeReplicationGroupsOutput
 		result2 error
 	}
+	DescribeCacheClustersWithContextStub        func(ctx aws.Context, input *elasticache.DescribeCacheClustersInput, opts ...request.Option) (*elasticache.DescribeCacheClustersOutput, error)
+	describeCacheClustersWithContextMutex       sync.RWMutex
+	describeCacheClustersWithContextArgsForCall []struct {
+		ctx   aws.Context
+		input *elasticache.DescribeCacheClustersInput
+		opts  []request.Option
+	}
+	describeCacheClustersWithContextReturns struct {
+		result1 *elasticache.DescribeCacheClustersOutput
+		result2 error
+	}
+	describeCacheClustersWithContextReturnsOnCall map[int]struct {
+		result1 *elasticache.DescribeCacheClustersOutput
+		result2 error
+	}
+	DescribeCacheParametersWithContextStub        func(ctx aws.Context, input *elasticache.DescribeCacheParametersInput, opts ...request.Option) (*elasticache.DescribeCacheParametersOutput, error)
+	describeCacheParametersWithContextMutex       sync.RWMutex
+	describeCacheParametersWithContextArgsForCall []struct {
+		ctx   aws.Context
+		input *elasticache.DescribeCacheParametersInput
+		opts  []request.Option
+	}
+	describeCacheParametersWithContextReturns struct {
+		result1 *elasticache.DescribeCacheParametersOutput
+		result2 error
+	}
+	describeCacheParametersWithContextReturnsOnCall map[int]struct {
+		result1 *elasticache.DescribeCacheParametersOutput
+		result2 error
+	}
 	ModifyCacheParameterGroupWithContextStub        func(ctx aws.Context, input *elasticache.ModifyCacheParameterGroupInput, opts ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error)
 	modifyCacheParameterGroupWithContextMutex       sync.RWMutex
 	modifyCacheParameterGroupWithContextArgsForCall []struct {
@@ -399,6 +429,112 @@ func (fake *FakeElastiCache) DescribeReplicationGroupsWithContextReturnsOnCall(i
 	}{result1, result2}
 }
 
+func (fake *FakeElastiCache) DescribeCacheClustersWithContext(ctx aws.Context, input *elasticache.DescribeCacheClustersInput, opts ...request.Option) (*elasticache.DescribeCacheClustersOutput, error) {
+	fake.describeCacheClustersWithContextMutex.Lock()
+	ret, specificReturn := fake.describeCacheClustersWithContextReturnsOnCall[len(fake.describeCacheClustersWithContextArgsForCall)]
+	fake.describeCacheClustersWithContextArgsForCall = append(fake.describeCacheClustersWithContextArgsForCall, struct {
+		ctx   aws.Context
+		input *elasticache.DescribeCacheClustersInput
+		opts  []request.Option
+	}{ctx, input, opts})
+	fake.recordInvocation("DescribeCacheClustersWithContext", []interface{}{ctx, input, opts})
+	fake.describeCacheClustersWithContextMutex.Unlock()
+	if fake.DescribeCacheClustersWithContextStub != nil {
+		return fake.DescribeCacheClustersWithContextStub(ctx, input, opts...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.describeCacheClustersWithContextReturns.result1, fake.describeCacheClustersWithContextReturns.result2
+}
+
+func (fake *FakeElastiCache) DescribeCacheClustersWithContextCallCount() int {
+	fake.describeCacheClustersWithContextMutex.RLock()
+	defer fake.describeCacheClustersWithContextMutex.RUnlock()
+	return len(fake.describeCacheClustersWithContextArgsForCall)
+}
+
+func (fake *FakeElastiCache) DescribeCacheClustersWithContextArgsForCall(i int) (aws.Context, *elasticache.DescribeCacheClustersInput, []request.Option) {
+	fake.describeCacheClustersWithContextMutex.RLock()
+	defer fake.describeCacheClustersWithContextMutex.RUnlock()
+	return fake.describeCacheClustersWithContextArgsForCall[i].ctx, fake.describeCacheClustersWithContextArgsForCall[i].input, fake.describeCacheClustersWithContextArgsForCall[i].opts
+}
+
+func (fake *FakeElastiCache) DescribeCacheClustersWithContextReturns(result1 *elasticache.DescribeCacheClustersOutput, result2 error) {
+	fake.DescribeCacheClustersWithContextStub = nil
+	fake.describeCacheClustersWithContextReturns = struct {
+		result1 *elasticache.DescribeCacheClustersOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) DescribeCacheClustersWithContextReturnsOnCall(i int, result1 *elasticache.DescribeCacheClustersOutput, result2 error) {
+	fake.DescribeCacheClustersWithContextStub = nil
+	if fake.describeCacheClustersWithContextReturnsOnCall == nil {
+		fake.describeCacheClustersWithContextReturnsOnCall = make(map[int]struct {
+			result1 *elasticache.DescribeCacheClustersOutput
+			result2 error
+		})
+	}
+	fake.describeCacheClustersWithContextReturnsOnCall[i] = struct {
+		result1 *elasticache.DescribeCacheClustersOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) DescribeCacheParametersWithContext(ctx aws.Context, input *elasticache.DescribeCacheParametersInput, opts ...request.Option) (*elasticache.DescribeCacheParametersOutput, error) {
+	fake.describeCacheParametersWithContextMutex.Lock()
+	ret, specificReturn := fake.describeCacheParametersWithContextReturnsOnCall[len(fake.describeCacheParametersWithContextArgsForCall)]
+	fake.describeCacheParametersWithContextArgsForCall = append(fake.describeCacheParametersWithContextArgsForCall, struct {
+		ctx   aws.Context
+		input *elasticache.DescribeCacheParametersInput
+		opts  []request.Option
+	}{ctx, input, opts})
+	fake.recordInvocation("DescribeCacheParametersWithContext", []interface{}{ctx, input, opts})
+	fake.describeCacheParametersWithContextMutex.Unlock()
+	if fake.DescribeCacheParametersWithContextStub != nil {
+		return fake.DescribeCacheParametersWithContextStub(ctx, input, opts...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.describeCacheParametersWithContextReturns.result1, fake.describeCacheParametersWithContextReturns.result2
+}
+
+func (fake *FakeElastiCache) DescribeCacheParametersWithContextCallCount() int {
+	fake.describeCacheParametersWithContextMutex.RLock()
+	defer fake.describeCacheParametersWithContextMutex.RUnlock()
+	return len(fake.describeCacheParametersWithContextArgsForCall)
+}
+
+func (fake *FakeElastiCache) DescribeCacheParametersWithContextArgsForCall(i int) (aws.Context, *elasticache.DescribeCacheParametersInput, []request.Option) {
+	fake.describeCacheParametersWithContextMutex.RLock()
+	defer fake.describeCacheParametersWithContextMutex.RUnlock()
+	return fake.describeCacheParametersWithContextArgsForCall[i].ctx, fake.describeCacheParametersWithContextArgsForCall[i].input, fake.describeCacheParametersWithContextArgsForCall[i].opts
+}
+
+func (fake *FakeElastiCache) DescribeCacheParametersWithContextReturns(result1 *elasticache.DescribeCacheParametersOutput, result2 error) {
+	fake.DescribeCacheParametersWithContextStub = nil
+	fake.describeCacheParametersWithContextReturns = struct {
+		result1 *elasticache.DescribeCacheParametersOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) DescribeCacheParametersWithContextReturnsOnCall(i int, result1 *elasticache.DescribeCacheParametersOutput, result2 error) {
+	fake.DescribeCacheParametersWithContextStub = nil
+	if fake.describeCacheParametersWithContextReturnsOnCall == nil {
+		fake.describeCacheParametersWithContextReturnsOnCall = make(map[int]struct {
+			result1 *elasticache.DescribeCacheParametersOutput
+			result2 error
+		})
+	}
+	fake.describeCacheParametersWithContextReturnsOnCall[i] = struct {
+		result1 *elasticache.DescribeCacheParametersOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeElastiCache) ModifyCacheParameterGroupWithContext(ctx aws.Context, input *elasticache.ModifyCacheParameterGroupInput, opts ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error) {
 	fake.modifyCacheParameterGroupWithContextMutex.Lock()
 	ret, specificReturn := fake.modifyCacheParameterGroupWithContextReturnsOnCall[len(fake.modifyCacheParameterGroupWithContextArgsForCall)]
@@ -569,6 +705,10 @@ func (fake *FakeElastiCache) Invocations() map[string][][]interface{} {
 	defer fake.deleteReplicationGroupWithContextMutex.RUnlock()
 	fake.describeReplicationGroupsWithContextMutex.RLock()
 	defer fake.describeReplicationGroupsWithContextMutex.RUnlock()
+	fake.describeCacheClustersWithContextMutex.RLock()
+	defer fake.describeCacheClustersWithContextMutex.RUnlock()
+	fake.describeCacheParametersWithContextMutex.RLock()
+	defer fake.describeCacheParametersWithContextMutex.RUnlock()
 	fake.modifyCacheParameterGroupWithContextMutex.RLock()
 	defer fake.modifyCacheParameterGroupWithContextMutex.RUnlock()
 	fake.describeSnapshotsPagesWithContextMutex.RLock()

--- a/providers/mocks/provider.go
+++ b/providers/mocks/provider.go
@@ -22,6 +22,19 @@ type FakeProvider struct {
 	provisionReturnsOnCall map[int]struct {
 		result1 error
 	}
+	UpdateStub        func(ctx context.Context, instanceID string, params providers.UpdateParameters) error
+	updateMutex       sync.RWMutex
+	updateArgsForCall []struct {
+		ctx        context.Context
+		instanceID string
+		params     providers.UpdateParameters
+	}
+	updateReturns struct {
+		result1 error
+	}
+	updateReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeprovisionStub        func(ctx context.Context, instanceID string, params providers.DeprovisionParameters) error
 	deprovisionMutex       sync.RWMutex
 	deprovisionArgsForCall []struct {
@@ -155,6 +168,56 @@ func (fake *FakeProvider) ProvisionReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.provisionReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeProvider) Update(ctx context.Context, instanceID string, params providers.UpdateParameters) error {
+	fake.updateMutex.Lock()
+	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
+	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
+		ctx        context.Context
+		instanceID string
+		params     providers.UpdateParameters
+	}{ctx, instanceID, params})
+	fake.recordInvocation("Update", []interface{}{ctx, instanceID, params})
+	fake.updateMutex.Unlock()
+	if fake.UpdateStub != nil {
+		return fake.UpdateStub(ctx, instanceID, params)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.updateReturns.result1
+}
+
+func (fake *FakeProvider) UpdateCallCount() int {
+	fake.updateMutex.RLock()
+	defer fake.updateMutex.RUnlock()
+	return len(fake.updateArgsForCall)
+}
+
+func (fake *FakeProvider) UpdateArgsForCall(i int) (context.Context, string, providers.UpdateParameters) {
+	fake.updateMutex.RLock()
+	defer fake.updateMutex.RUnlock()
+	return fake.updateArgsForCall[i].ctx, fake.updateArgsForCall[i].instanceID, fake.updateArgsForCall[i].params
+}
+
+func (fake *FakeProvider) UpdateReturns(result1 error) {
+	fake.UpdateStub = nil
+	fake.updateReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeProvider) UpdateReturnsOnCall(i int, result1 error) {
+	fake.UpdateStub = nil
+	if fake.updateReturnsOnCall == nil {
+		fake.updateReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -473,6 +536,8 @@ func (fake *FakeProvider) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
+	fake.updateMutex.RLock()
+	defer fake.updateMutex.RUnlock()
 	fake.deprovisionMutex.RLock()
 	defer fake.deprovisionMutex.RUnlock()
 	fake.getStateMutex.RLock()

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -38,6 +38,10 @@ type DeprovisionParameters struct {
 	FinalSnapshotIdentifier string
 }
 
+type UpdateParameters struct {
+	Parameters map[string]string
+}
+
 type SnapshotInfo struct {
 	Name       string
 	CreateTime time.Time
@@ -49,6 +53,7 @@ type SnapshotInfo struct {
 //go:generate counterfeiter -o mocks/provider.go . Provider
 type Provider interface {
 	Provision(ctx context.Context, instanceID string, params ProvisionParameters) error
+	Update(ctx context.Context, instanceID string, params UpdateParameters) error
 	Deprovision(ctx context.Context, instanceID string, params DeprovisionParameters) error
 	GetState(ctx context.Context, instanceID string) (ServiceState, string, error)
 	GenerateCredentials(ctx context.Context, instanceID, bindingID string) (*Credentials, error)

--- a/providers/redis/redis.go
+++ b/providers/redis/redis.go
@@ -160,7 +160,7 @@ func (p *RedisProvider) Deprovision(ctx context.Context, instanceID string, para
 
 func (p *RedisProvider) getMessage(ctx context.Context, replicationGroup *elasticache.ReplicationGroup) string {
 	tmpl := "%-20s : %s"
-	msgs := []string{"\n"}
+	msgs := []string{"---"}
 	if replicationGroup.Status != nil {
 		msgs = append(msgs, fmt.Sprintf(tmpl, "status", *replicationGroup.Status))
 	} else {
@@ -185,7 +185,7 @@ func (p *RedisProvider) getMessage(ctx context.Context, replicationGroup *elasti
 							continue
 						}
 						if *param.ParameterName == "maxmemory-policy" && param.ParameterValue != nil {
-							msgs = append(msgs, fmt.Sprintf(tmpl, "maxmemory policy", *param.ParameterValue))
+							msgs = append(msgs, fmt.Sprintf(tmpl, "maxmemory policy", strings.TrimSpace(*param.ParameterValue)))
 						}
 					}
 				}


### PR DESCRIPTION
# What

We want to allow our tenants to set the maxmemory-policy setting when creating or updating Redis instances.

In this change we introduce a new parameter called maxmemory_policy (with underscore to keep it consistent with already existing parameters) which can be passed when creating or updating a redis service.

This change doesn't require a cluster restart in Elasticache.

Parameters are validated by the broker and the values of maxmemory_policy are validated by the AWS API.

We also amended the last operation status message to return with cluster related information to make our tenants happy.

```
status:    update succeeded
message:   ---
           status               : available
           cluster id           : cf-4zh4ckflsu6fa
           engine version       : 3.2.6
           maxmemory policy     : volatile-ttl
           maintenance window   : sun:23:00-mon:01:30
           daily backup window  : 02:00-05:00
started:   2018-02-15T12:46:04Z
updated:   2018-02-15T12:46:06Z
```

# How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1230

# Who can review

Not @chrisfarms nor @bandesz 