### PR TITLE
[#156226677] Secure instance passwords (cleanup part)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ You have to pass in a configuration JSON file with the following format:
   "broker_name": "Broker name",
   "username": "Broker http auth username",
   "password": "Broker http auth password",
-  "auth_token_seed": "common auth token seed (secret)",
   "region": "<%= p('elasticache-broker.region') %>",
   "cache_subnet_group_name": "AWS Elasticache cache subnet group name",
   "vpc_security_group_ids": "List of AWS security group ids",

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -23,7 +23,6 @@ var _ = Describe("Broker", func() {
 
 	BeforeEach(func() {
 		validConfig = broker.Config{
-			AuthTokenSeed:        "super-secret",
 			BrokerName:           "Broker McBrokerface",
 			VpcSecurityGroupIds:  []string{"vpc_security_group_id"},
 			CacheSubnetGroupName: "cache-subnet-group-name",

--- a/broker/config.go
+++ b/broker/config.go
@@ -31,7 +31,6 @@ type Config struct {
 	Password             string                    `json:"password"`
 	Region               string                    `json:"region"`
 	BrokerName           string                    `json:"broker_name"`
-	AuthTokenSeed        string                    `json:"auth_token_seed"` // TODO: remove after all auth tokens were migrated to the Secrets Manager
 	CacheSubnetGroupName string                    `json:"cache_subnet_group_name"`
 	VpcSecurityGroupIds  []string                  `json:"vpc_security_group_ids"`
 	Catalog              brokerapi.CatalogResponse `json:"catalog"`
@@ -94,10 +93,6 @@ func (c Config) Validate() error {
 
 	if c.BrokerName == "" {
 		return errors.New("Must provide a non-empty broker_name")
-	}
-
-	if c.AuthTokenSeed == "" {
-		return errors.New("Must provide a non-empty auth_token_seed")
 	}
 
 	if c.CacheSubnetGroupName == "" {

--- a/broker/config_test.go
+++ b/broker/config_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Config", func() {
 			Password:             "password",
 			Region:               "region",
 			BrokerName:           "broker_name",
-			AuthTokenSeed:        "auth_token_seed",
 			CacheSubnetGroupName: "cache_subnet_group_name",
 			VpcSecurityGroupIds:  []string{"vpc_security_group_id"},
 			Catalog: brokerapi.CatalogResponse{
@@ -71,11 +70,6 @@ var _ = Describe("Config", func() {
 
 		It("requires a broker name", func() {
 			config.BrokerName = ""
-			Expect(config.Validate()).NotTo(Succeed())
-		})
-
-		It("requires an auth token seed", func() {
-			config.AuthTokenSeed = ""
 			Expect(config.Validate()).NotTo(Succeed())
 		})
 

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -8,7 +8,6 @@
 	"password": "password",
 	"broker_name": "elasticache-integration-test",
 	"secrets_manager_path": "elasticache-broker-test",
-	"auth_token_seed": "sesamesunflower",
 	"kms_key_id": "alias/elasticache-broker-test",
 	"catalog": {
 		"services": [

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func newBroker(config broker.Config, logger lager.Logger) (*broker.Broker, error
 
 	provider := redis.NewProvider(
 		elastiCache, secretsManager, awsAccountID, awsPartition, awsRegion, logger,
-		config.AuthTokenSeed, config.KmsKeyID, config.SecretsManagerPath,
+		config.KmsKeyID, config.SecretsManagerPath,
 	)
 
 	return broker.New(config, provider, logger), nil


### PR DESCRIPTION
## What

In https://github.com/alphagov/paas-elasticache-broker/pull/13 we started to generate and store auth tokens in Secrets Manager.

This PR removes the deprecated bits as the auth token seed and the temporary migration method.

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1320

## Who can review

Not @46bit or me.
