### PR TITLE
Document necessary secretsmanager permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ The password will be the same for all bindings as the ElastiCache Redis replicat
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:<region>:<account-id>:secret:<path>/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
I haven't been able to test this yet at work (see https://github.com/alphagov/paas-elasticache-broker/issues/6#issuecomment-383774225), but these should be the correct permissions based on reading the source.