### PR TITLE
Provide empty username in connection URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ When binding a service instance to an application the *Bind* call returns the fo
   "host": "redis-host",
   "port": 6379,
   "password": "pass",
-  "uri": "rediss://x:pass@redis-host:6379",
+  "uri": "rediss://:pass@redis-host:6379",
   "tls_enabled": true
 }
 ```

--- a/providers/redis/redis.go
+++ b/providers/redis/redis.go
@@ -357,7 +357,9 @@ func (p *RedisProvider) GenerateCredentials(ctx context.Context, instanceID, bin
 	uri := &url.URL{
 		Scheme: "rediss",
 		Host:   fmt.Sprintf("%s:%d", host, port),
-		User:   url.UserPassword("x", authToken),
+		// Provide an empty string for username, it's not used for Redis 5, and breaks libraries which support Redis 6 too.
+		// TODO: Revisit this with Redis 6 support?
+		User:   url.UserPassword("", authToken),
 	}
 	return &providers.Credentials{
 		Host:       host,

--- a/providers/redis/redis_test.go
+++ b/providers/redis/redis_test.go
@@ -677,7 +677,7 @@ var _ = Describe("Provider", func() {
 				Port:       1234,
 				Name:       "cf-qwkec4pxhft6q",
 				Password:   "Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4=",
-				URI:        "rediss://x:Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4=@test-host:1234",
+				URI:        "rediss://:Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4=@test-host:1234",
 				TLSEnabled: true,
 			}))
 		})
@@ -715,7 +715,7 @@ var _ = Describe("Provider", func() {
 					Port:       1234,
 					Name:       "cf-qwkec4pxhft6q",
 					Password:   "Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4=",
-					URI:        "rediss://x:Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4=@test-host:1234",
+					URI:        "rediss://:Jc9xP_jNPaWtqIry7D-EuRlsm_z_-D_dtIVQhEv6oR4=@test-host:1234",
 					TLSEnabled: true,
 				}))
 			})


### PR DESCRIPTION
It's not used for Redis 5, and breaks libraries which support Redis 6, e.g.
newer versions of node-redis.