### PR TITLE
Add test_failover option to broker to allow a user to test the failover of their ha cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test: unit integration
 unit:
 	go run github.com/onsi/ginkgo/v2/ginkgo -r --skip-package=ci
 integration:
-	go run github.com/onsi/ginkgo/v2/ginkgo -v -r ci/blackbox
+	go run github.com/onsi/ginkgo/v2/ginkgo -timeout=120m -v -r ci/blackbox
 
 generate-fakes:
 	go generate ./...

--- a/broker/api_test.go
+++ b/broker/api_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Broker", func() {
 	Describe("LastOperation", func() {
 		It("responds with 200 when the instance is available", func() {
 			instanceID := uuid.NewV4().String()
-			fakeProvider.GetStateReturns(providers.Available, "", nil)
+			fakeProvider.ProgressStateReturns(providers.Available, "", nil)
 			resp := DoRequest(brokerAPI, NewRequest(
 				"GET",
 				"/v2/service_instances/"+instanceID+"/last_operation",
@@ -231,7 +231,7 @@ var _ = Describe("Broker", func() {
 
 		It("responds with a 500 when the state can't be retrieved", func() {
 			instanceID := uuid.NewV4().String()
-			fakeProvider.GetStateReturns("", "", errors.New("ohai"))
+			fakeProvider.ProgressStateReturns("", "", errors.New("ohai"))
 
 			resp := DoRequest(brokerAPI, NewRequest(
 				"GET",
@@ -247,7 +247,7 @@ var _ = Describe("Broker", func() {
 
 		It("responds with 410 when the instance doesn't exist", func() {
 			instanceID := uuid.NewV4().String()
-			fakeProvider.GetStateReturns(providers.NonExisting, "", nil)
+			fakeProvider.ProgressStateReturns(providers.NonExisting, "", nil)
 			resp := DoRequest(brokerAPI, NewRequest(
 				"GET",
 				"/v2/service_instances/"+instanceID+"/last_operation",

--- a/broker/parameters.go
+++ b/broker/parameters.go
@@ -8,6 +8,7 @@ import (
 const ParamRestoreLatestSnapshotOf = "restore_from_latest_snapshot_of"
 const ParamMaxMemoryPolicy = "maxmemory_policy"
 const ParamPreferredMaintenanceWindow = "preferred_maintenance_window"
+const TestFailover = "test_failover"
 
 func parseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 	params := &ProvisionParameters{}
@@ -22,11 +23,18 @@ func parseProvisionParameters(data []byte) (*ProvisionParameters, error) {
 	return params, nil
 }
 
+func checkIfNoUpdateParametersAreSet(params *UpdateParameters) bool {
+	return params.MaxMemoryPolicy == nil &&
+		params.PreferredMaintenanceWindow == "" &&
+		params.TestFailover == nil
+}
+
 func parseUpdateParameters(data []byte) (*UpdateParameters, error) {
 	params := &UpdateParameters{}
 	err := unmarshalParameters(data, params, []string{
 		ParamMaxMemoryPolicy,
 		ParamPreferredMaintenanceWindow,
+		TestFailover,
 	})
 	if err != nil {
 		return nil, err
@@ -64,4 +72,5 @@ type ProvisionParameters struct {
 type UpdateParameters struct {
 	MaxMemoryPolicy            *string `json:"maxmemory_policy"`
 	PreferredMaintenanceWindow string  `json:"preferred_maintenance_window"`
+	TestFailover               *bool   `json:"test_failover"`
 }

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -32,20 +32,20 @@
 	},
 	"plan_configs": {
 		"94767b71-2b9c-4960-a4f8-77b81a96f7e0": {
-			"instance_type": "cache.t2.micro",
-			"replicas_per_node_group": 0,
+			"instance_type": "cache.t3.micro",
+			"replicas_per_node_group": 1,
 			"shard_count": 1,
 			"snapshot_retention_limit": 1,
 			"automatic_failover_enabled": true,
-			"multi_az_enabled": false,
+			"multi_az_enabled": true,
 			"parameters": {
-				"cluster-enabled": "yes",
+				"cluster-enabled": "no",
 				"maxmemory-policy": "volatile-lru",
-				"reserved-memory": "0"
+				"reserved-memory-percent": "0"
 			},
 			"engine": "redis",
-			"engine_version": "3.2.6",
-			"cache_parameter_group_family": "redis3.2"
+			"engine_version": "6.2",
+			"cache_parameter_group_family": "redis6.x"
 		}
 	}
 }

--- a/ci/helpers/aws_helper.go
+++ b/ci/helpers/aws_helper.go
@@ -129,7 +129,7 @@ func ReplicationGroupARN(session *session.Session, replicationGroupID string) (s
 	awsAccountID := aws.StringValue(getCallerIdentityOutput.Account)
 
 	return fmt.Sprintf(
-		"arn:%s:elasticache:%s:%s:cluster:%s-0001-001",
+		"arn:%s:elasticache:%s:%s:cluster:%s-001",
 		awsPartition,
 		awsRegion,
 		awsAccountID,

--- a/providers/elasticache.go
+++ b/providers/elasticache.go
@@ -22,4 +22,7 @@ type ElastiCache interface {
 	ModifyCacheParameterGroupWithContext(ctx aws.Context, input *elasticache.ModifyCacheParameterGroupInput, opts ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error)
 	DescribeSnapshotsPagesWithContext(ctx aws.Context, input *elasticache.DescribeSnapshotsInput, fn func(*elasticache.DescribeSnapshotsOutput, bool) bool, opts ...request.Option) error
 	ListTagsForResourceWithContext(ctx aws.Context, input *elasticache.ListTagsForResourceInput, opts ...request.Option) (*elasticache.TagListMessage, error)
+	TestFailoverWithContext(ctx aws.Context, input *elasticache.TestFailoverInput, opts ...request.Option) (*elasticache.TestFailoverOutput, error)
+	AddTagsToResourceWithContext(ctx aws.Context, input *elasticache.AddTagsToResourceInput, opts ...request.Option) (*elasticache.TagListMessage, error)
+	RemoveTagsFromResourceWithContext(ctx aws.Context, input *elasticache.RemoveTagsFromResourceInput, opts ...request.Option) (*elasticache.TagListMessage, error)
 }

--- a/providers/mocks/elasticache.go
+++ b/providers/mocks/elasticache.go
@@ -11,6 +11,21 @@ import (
 )
 
 type FakeElastiCache struct {
+	AddTagsToResourceWithContextStub        func(context.Context, *elasticache.AddTagsToResourceInput, ...request.Option) (*elasticache.TagListMessage, error)
+	addTagsToResourceWithContextMutex       sync.RWMutex
+	addTagsToResourceWithContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 *elasticache.AddTagsToResourceInput
+		arg3 []request.Option
+	}
+	addTagsToResourceWithContextReturns struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}
+	addTagsToResourceWithContextReturnsOnCall map[int]struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}
 	CreateCacheParameterGroupWithContextStub        func(context.Context, *elasticache.CreateCacheParameterGroupInput, ...request.Option) (*elasticache.CreateCacheParameterGroupOutput, error)
 	createCacheParameterGroupWithContextMutex       sync.RWMutex
 	createCacheParameterGroupWithContextArgsForCall []struct {
@@ -175,8 +190,104 @@ type FakeElastiCache struct {
 		result1 *elasticache.ModifyReplicationGroupOutput
 		result2 error
 	}
+	RemoveTagsFromResourceWithContextStub        func(context.Context, *elasticache.RemoveTagsFromResourceInput, ...request.Option) (*elasticache.TagListMessage, error)
+	removeTagsFromResourceWithContextMutex       sync.RWMutex
+	removeTagsFromResourceWithContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 *elasticache.RemoveTagsFromResourceInput
+		arg3 []request.Option
+	}
+	removeTagsFromResourceWithContextReturns struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}
+	removeTagsFromResourceWithContextReturnsOnCall map[int]struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}
+	TestFailoverWithContextStub        func(context.Context, *elasticache.TestFailoverInput, ...request.Option) (*elasticache.TestFailoverOutput, error)
+	testFailoverWithContextMutex       sync.RWMutex
+	testFailoverWithContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 *elasticache.TestFailoverInput
+		arg3 []request.Option
+	}
+	testFailoverWithContextReturns struct {
+		result1 *elasticache.TestFailoverOutput
+		result2 error
+	}
+	testFailoverWithContextReturnsOnCall map[int]struct {
+		result1 *elasticache.TestFailoverOutput
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeElastiCache) AddTagsToResourceWithContext(arg1 context.Context, arg2 *elasticache.AddTagsToResourceInput, arg3 ...request.Option) (*elasticache.TagListMessage, error) {
+	fake.addTagsToResourceWithContextMutex.Lock()
+	ret, specificReturn := fake.addTagsToResourceWithContextReturnsOnCall[len(fake.addTagsToResourceWithContextArgsForCall)]
+	fake.addTagsToResourceWithContextArgsForCall = append(fake.addTagsToResourceWithContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 *elasticache.AddTagsToResourceInput
+		arg3 []request.Option
+	}{arg1, arg2, arg3})
+	stub := fake.AddTagsToResourceWithContextStub
+	fakeReturns := fake.addTagsToResourceWithContextReturns
+	fake.recordInvocation("AddTagsToResourceWithContext", []interface{}{arg1, arg2, arg3})
+	fake.addTagsToResourceWithContextMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeElastiCache) AddTagsToResourceWithContextCallCount() int {
+	fake.addTagsToResourceWithContextMutex.RLock()
+	defer fake.addTagsToResourceWithContextMutex.RUnlock()
+	return len(fake.addTagsToResourceWithContextArgsForCall)
+}
+
+func (fake *FakeElastiCache) AddTagsToResourceWithContextCalls(stub func(context.Context, *elasticache.AddTagsToResourceInput, ...request.Option) (*elasticache.TagListMessage, error)) {
+	fake.addTagsToResourceWithContextMutex.Lock()
+	defer fake.addTagsToResourceWithContextMutex.Unlock()
+	fake.AddTagsToResourceWithContextStub = stub
+}
+
+func (fake *FakeElastiCache) AddTagsToResourceWithContextArgsForCall(i int) (context.Context, *elasticache.AddTagsToResourceInput, []request.Option) {
+	fake.addTagsToResourceWithContextMutex.RLock()
+	defer fake.addTagsToResourceWithContextMutex.RUnlock()
+	argsForCall := fake.addTagsToResourceWithContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeElastiCache) AddTagsToResourceWithContextReturns(result1 *elasticache.TagListMessage, result2 error) {
+	fake.addTagsToResourceWithContextMutex.Lock()
+	defer fake.addTagsToResourceWithContextMutex.Unlock()
+	fake.AddTagsToResourceWithContextStub = nil
+	fake.addTagsToResourceWithContextReturns = struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) AddTagsToResourceWithContextReturnsOnCall(i int, result1 *elasticache.TagListMessage, result2 error) {
+	fake.addTagsToResourceWithContextMutex.Lock()
+	defer fake.addTagsToResourceWithContextMutex.Unlock()
+	fake.AddTagsToResourceWithContextStub = nil
+	if fake.addTagsToResourceWithContextReturnsOnCall == nil {
+		fake.addTagsToResourceWithContextReturnsOnCall = make(map[int]struct {
+			result1 *elasticache.TagListMessage
+			result2 error
+		})
+	}
+	fake.addTagsToResourceWithContextReturnsOnCall[i] = struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeElastiCache) CreateCacheParameterGroupWithContext(arg1 context.Context, arg2 *elasticache.CreateCacheParameterGroupInput, arg3 ...request.Option) (*elasticache.CreateCacheParameterGroupOutput, error) {
@@ -903,9 +1014,143 @@ func (fake *FakeElastiCache) ModifyReplicationGroupWithContextReturnsOnCall(i in
 	}{result1, result2}
 }
 
+func (fake *FakeElastiCache) RemoveTagsFromResourceWithContext(arg1 context.Context, arg2 *elasticache.RemoveTagsFromResourceInput, arg3 ...request.Option) (*elasticache.TagListMessage, error) {
+	fake.removeTagsFromResourceWithContextMutex.Lock()
+	ret, specificReturn := fake.removeTagsFromResourceWithContextReturnsOnCall[len(fake.removeTagsFromResourceWithContextArgsForCall)]
+	fake.removeTagsFromResourceWithContextArgsForCall = append(fake.removeTagsFromResourceWithContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 *elasticache.RemoveTagsFromResourceInput
+		arg3 []request.Option
+	}{arg1, arg2, arg3})
+	stub := fake.RemoveTagsFromResourceWithContextStub
+	fakeReturns := fake.removeTagsFromResourceWithContextReturns
+	fake.recordInvocation("RemoveTagsFromResourceWithContext", []interface{}{arg1, arg2, arg3})
+	fake.removeTagsFromResourceWithContextMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeElastiCache) RemoveTagsFromResourceWithContextCallCount() int {
+	fake.removeTagsFromResourceWithContextMutex.RLock()
+	defer fake.removeTagsFromResourceWithContextMutex.RUnlock()
+	return len(fake.removeTagsFromResourceWithContextArgsForCall)
+}
+
+func (fake *FakeElastiCache) RemoveTagsFromResourceWithContextCalls(stub func(context.Context, *elasticache.RemoveTagsFromResourceInput, ...request.Option) (*elasticache.TagListMessage, error)) {
+	fake.removeTagsFromResourceWithContextMutex.Lock()
+	defer fake.removeTagsFromResourceWithContextMutex.Unlock()
+	fake.RemoveTagsFromResourceWithContextStub = stub
+}
+
+func (fake *FakeElastiCache) RemoveTagsFromResourceWithContextArgsForCall(i int) (context.Context, *elasticache.RemoveTagsFromResourceInput, []request.Option) {
+	fake.removeTagsFromResourceWithContextMutex.RLock()
+	defer fake.removeTagsFromResourceWithContextMutex.RUnlock()
+	argsForCall := fake.removeTagsFromResourceWithContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeElastiCache) RemoveTagsFromResourceWithContextReturns(result1 *elasticache.TagListMessage, result2 error) {
+	fake.removeTagsFromResourceWithContextMutex.Lock()
+	defer fake.removeTagsFromResourceWithContextMutex.Unlock()
+	fake.RemoveTagsFromResourceWithContextStub = nil
+	fake.removeTagsFromResourceWithContextReturns = struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) RemoveTagsFromResourceWithContextReturnsOnCall(i int, result1 *elasticache.TagListMessage, result2 error) {
+	fake.removeTagsFromResourceWithContextMutex.Lock()
+	defer fake.removeTagsFromResourceWithContextMutex.Unlock()
+	fake.RemoveTagsFromResourceWithContextStub = nil
+	if fake.removeTagsFromResourceWithContextReturnsOnCall == nil {
+		fake.removeTagsFromResourceWithContextReturnsOnCall = make(map[int]struct {
+			result1 *elasticache.TagListMessage
+			result2 error
+		})
+	}
+	fake.removeTagsFromResourceWithContextReturnsOnCall[i] = struct {
+		result1 *elasticache.TagListMessage
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) TestFailoverWithContext(arg1 context.Context, arg2 *elasticache.TestFailoverInput, arg3 ...request.Option) (*elasticache.TestFailoverOutput, error) {
+	fake.testFailoverWithContextMutex.Lock()
+	ret, specificReturn := fake.testFailoverWithContextReturnsOnCall[len(fake.testFailoverWithContextArgsForCall)]
+	fake.testFailoverWithContextArgsForCall = append(fake.testFailoverWithContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 *elasticache.TestFailoverInput
+		arg3 []request.Option
+	}{arg1, arg2, arg3})
+	stub := fake.TestFailoverWithContextStub
+	fakeReturns := fake.testFailoverWithContextReturns
+	fake.recordInvocation("TestFailoverWithContext", []interface{}{arg1, arg2, arg3})
+	fake.testFailoverWithContextMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeElastiCache) TestFailoverWithContextCallCount() int {
+	fake.testFailoverWithContextMutex.RLock()
+	defer fake.testFailoverWithContextMutex.RUnlock()
+	return len(fake.testFailoverWithContextArgsForCall)
+}
+
+func (fake *FakeElastiCache) TestFailoverWithContextCalls(stub func(context.Context, *elasticache.TestFailoverInput, ...request.Option) (*elasticache.TestFailoverOutput, error)) {
+	fake.testFailoverWithContextMutex.Lock()
+	defer fake.testFailoverWithContextMutex.Unlock()
+	fake.TestFailoverWithContextStub = stub
+}
+
+func (fake *FakeElastiCache) TestFailoverWithContextArgsForCall(i int) (context.Context, *elasticache.TestFailoverInput, []request.Option) {
+	fake.testFailoverWithContextMutex.RLock()
+	defer fake.testFailoverWithContextMutex.RUnlock()
+	argsForCall := fake.testFailoverWithContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeElastiCache) TestFailoverWithContextReturns(result1 *elasticache.TestFailoverOutput, result2 error) {
+	fake.testFailoverWithContextMutex.Lock()
+	defer fake.testFailoverWithContextMutex.Unlock()
+	fake.TestFailoverWithContextStub = nil
+	fake.testFailoverWithContextReturns = struct {
+		result1 *elasticache.TestFailoverOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeElastiCache) TestFailoverWithContextReturnsOnCall(i int, result1 *elasticache.TestFailoverOutput, result2 error) {
+	fake.testFailoverWithContextMutex.Lock()
+	defer fake.testFailoverWithContextMutex.Unlock()
+	fake.TestFailoverWithContextStub = nil
+	if fake.testFailoverWithContextReturnsOnCall == nil {
+		fake.testFailoverWithContextReturnsOnCall = make(map[int]struct {
+			result1 *elasticache.TestFailoverOutput
+			result2 error
+		})
+	}
+	fake.testFailoverWithContextReturnsOnCall[i] = struct {
+		result1 *elasticache.TestFailoverOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeElastiCache) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.addTagsToResourceWithContextMutex.RLock()
+	defer fake.addTagsToResourceWithContextMutex.RUnlock()
 	fake.createCacheParameterGroupWithContextMutex.RLock()
 	defer fake.createCacheParameterGroupWithContextMutex.RUnlock()
 	fake.createReplicationGroupWithContextMutex.RLock()
@@ -928,6 +1173,10 @@ func (fake *FakeElastiCache) Invocations() map[string][][]interface{} {
 	defer fake.modifyCacheParameterGroupWithContextMutex.RUnlock()
 	fake.modifyReplicationGroupWithContextMutex.RLock()
 	defer fake.modifyReplicationGroupWithContextMutex.RUnlock()
+	fake.removeTagsFromResourceWithContextMutex.RLock()
+	defer fake.removeTagsFromResourceWithContextMutex.RUnlock()
+	fake.testFailoverWithContextMutex.RLock()
+	defer fake.testFailoverWithContextMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/providers/mocks/provider.go
+++ b/providers/mocks/provider.go
@@ -91,18 +91,20 @@ type FakeProvider struct {
 		result1 map[string]string
 		result2 error
 	}
-	GetStateStub        func(context.Context, string) (providers.ServiceState, string, error)
-	getStateMutex       sync.RWMutex
-	getStateArgsForCall []struct {
+	ProgressStateStub        func(context.Context, string, string, string) (providers.ServiceState, string, error)
+	progressStateMutex       sync.RWMutex
+	progressStateArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
+		arg3 string
+		arg4 string
 	}
-	getStateReturns struct {
+	progressStateReturns struct {
 		result1 providers.ServiceState
 		result2 string
 		result3 error
 	}
-	getStateReturnsOnCall map[int]struct {
+	progressStateReturnsOnCall map[int]struct {
 		result1 providers.ServiceState
 		result2 string
 		result3 error
@@ -132,6 +134,20 @@ type FakeProvider struct {
 	}
 	revokeCredentialsReturnsOnCall map[int]struct {
 		result1 error
+	}
+	StartFailoverTestStub        func(context.Context, string) (string, error)
+	startFailoverTestMutex       sync.RWMutex
+	startFailoverTestArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	startFailoverTestReturns struct {
+		result1 string
+		result2 error
+	}
+	startFailoverTestReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
 	}
 	UpdateParamGroupParametersStub        func(context.Context, string, providers.UpdateParamGroupParameters) error
 	updateParamGroupParametersMutex       sync.RWMutex
@@ -549,19 +565,21 @@ func (fake *FakeProvider) GetInstanceTagsReturnsOnCall(i int, result1 map[string
 	}{result1, result2}
 }
 
-func (fake *FakeProvider) GetState(arg1 context.Context, arg2 string) (providers.ServiceState, string, error) {
-	fake.getStateMutex.Lock()
-	ret, specificReturn := fake.getStateReturnsOnCall[len(fake.getStateArgsForCall)]
-	fake.getStateArgsForCall = append(fake.getStateArgsForCall, struct {
+func (fake *FakeProvider) ProgressState(arg1 context.Context, arg2 string, arg3 string, arg4 string) (providers.ServiceState, string, error) {
+	fake.progressStateMutex.Lock()
+	ret, specificReturn := fake.progressStateReturnsOnCall[len(fake.progressStateArgsForCall)]
+	fake.progressStateArgsForCall = append(fake.progressStateArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-	}{arg1, arg2})
-	stub := fake.GetStateStub
-	fakeReturns := fake.getStateReturns
-	fake.recordInvocation("GetState", []interface{}{arg1, arg2})
-	fake.getStateMutex.Unlock()
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.ProgressStateStub
+	fakeReturns := fake.progressStateReturns
+	fake.recordInvocation("ProgressState", []interface{}{arg1, arg2, arg3, arg4})
+	fake.progressStateMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -569,48 +587,48 @@ func (fake *FakeProvider) GetState(arg1 context.Context, arg2 string) (providers
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
-func (fake *FakeProvider) GetStateCallCount() int {
-	fake.getStateMutex.RLock()
-	defer fake.getStateMutex.RUnlock()
-	return len(fake.getStateArgsForCall)
+func (fake *FakeProvider) ProgressStateCallCount() int {
+	fake.progressStateMutex.RLock()
+	defer fake.progressStateMutex.RUnlock()
+	return len(fake.progressStateArgsForCall)
 }
 
-func (fake *FakeProvider) GetStateCalls(stub func(context.Context, string) (providers.ServiceState, string, error)) {
-	fake.getStateMutex.Lock()
-	defer fake.getStateMutex.Unlock()
-	fake.GetStateStub = stub
+func (fake *FakeProvider) ProgressStateCalls(stub func(context.Context, string, string, string) (providers.ServiceState, string, error)) {
+	fake.progressStateMutex.Lock()
+	defer fake.progressStateMutex.Unlock()
+	fake.ProgressStateStub = stub
 }
 
-func (fake *FakeProvider) GetStateArgsForCall(i int) (context.Context, string) {
-	fake.getStateMutex.RLock()
-	defer fake.getStateMutex.RUnlock()
-	argsForCall := fake.getStateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+func (fake *FakeProvider) ProgressStateArgsForCall(i int) (context.Context, string, string, string) {
+	fake.progressStateMutex.RLock()
+	defer fake.progressStateMutex.RUnlock()
+	argsForCall := fake.progressStateArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeProvider) GetStateReturns(result1 providers.ServiceState, result2 string, result3 error) {
-	fake.getStateMutex.Lock()
-	defer fake.getStateMutex.Unlock()
-	fake.GetStateStub = nil
-	fake.getStateReturns = struct {
+func (fake *FakeProvider) ProgressStateReturns(result1 providers.ServiceState, result2 string, result3 error) {
+	fake.progressStateMutex.Lock()
+	defer fake.progressStateMutex.Unlock()
+	fake.ProgressStateStub = nil
+	fake.progressStateReturns = struct {
 		result1 providers.ServiceState
 		result2 string
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *FakeProvider) GetStateReturnsOnCall(i int, result1 providers.ServiceState, result2 string, result3 error) {
-	fake.getStateMutex.Lock()
-	defer fake.getStateMutex.Unlock()
-	fake.GetStateStub = nil
-	if fake.getStateReturnsOnCall == nil {
-		fake.getStateReturnsOnCall = make(map[int]struct {
+func (fake *FakeProvider) ProgressStateReturnsOnCall(i int, result1 providers.ServiceState, result2 string, result3 error) {
+	fake.progressStateMutex.Lock()
+	defer fake.progressStateMutex.Unlock()
+	fake.ProgressStateStub = nil
+	if fake.progressStateReturnsOnCall == nil {
+		fake.progressStateReturnsOnCall = make(map[int]struct {
 			result1 providers.ServiceState
 			result2 string
 			result3 error
 		})
 	}
-	fake.getStateReturnsOnCall[i] = struct {
+	fake.progressStateReturnsOnCall[i] = struct {
 		result1 providers.ServiceState
 		result2 string
 		result3 error
@@ -741,6 +759,71 @@ func (fake *FakeProvider) RevokeCredentialsReturnsOnCall(i int, result1 error) {
 	fake.revokeCredentialsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeProvider) StartFailoverTest(arg1 context.Context, arg2 string) (string, error) {
+	fake.startFailoverTestMutex.Lock()
+	ret, specificReturn := fake.startFailoverTestReturnsOnCall[len(fake.startFailoverTestArgsForCall)]
+	fake.startFailoverTestArgsForCall = append(fake.startFailoverTestArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.StartFailoverTestStub
+	fakeReturns := fake.startFailoverTestReturns
+	fake.recordInvocation("StartFailoverTest", []interface{}{arg1, arg2})
+	fake.startFailoverTestMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeProvider) StartFailoverTestCallCount() int {
+	fake.startFailoverTestMutex.RLock()
+	defer fake.startFailoverTestMutex.RUnlock()
+	return len(fake.startFailoverTestArgsForCall)
+}
+
+func (fake *FakeProvider) StartFailoverTestCalls(stub func(context.Context, string) (string, error)) {
+	fake.startFailoverTestMutex.Lock()
+	defer fake.startFailoverTestMutex.Unlock()
+	fake.StartFailoverTestStub = stub
+}
+
+func (fake *FakeProvider) StartFailoverTestArgsForCall(i int) (context.Context, string) {
+	fake.startFailoverTestMutex.RLock()
+	defer fake.startFailoverTestMutex.RUnlock()
+	argsForCall := fake.startFailoverTestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeProvider) StartFailoverTestReturns(result1 string, result2 error) {
+	fake.startFailoverTestMutex.Lock()
+	defer fake.startFailoverTestMutex.Unlock()
+	fake.StartFailoverTestStub = nil
+	fake.startFailoverTestReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeProvider) StartFailoverTestReturnsOnCall(i int, result1 string, result2 error) {
+	fake.startFailoverTestMutex.Lock()
+	defer fake.startFailoverTestMutex.Unlock()
+	fake.StartFailoverTestStub = nil
+	if fake.startFailoverTestReturnsOnCall == nil {
+		fake.startFailoverTestReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.startFailoverTestReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeProvider) UpdateParamGroupParameters(arg1 context.Context, arg2 string, arg3 providers.UpdateParamGroupParameters) error {
@@ -884,12 +967,14 @@ func (fake *FakeProvider) Invocations() map[string][][]interface{} {
 	defer fake.getInstanceParametersMutex.RUnlock()
 	fake.getInstanceTagsMutex.RLock()
 	defer fake.getInstanceTagsMutex.RUnlock()
-	fake.getStateMutex.RLock()
-	defer fake.getStateMutex.RUnlock()
+	fake.progressStateMutex.RLock()
+	defer fake.progressStateMutex.RUnlock()
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
 	fake.revokeCredentialsMutex.RLock()
 	defer fake.revokeCredentialsMutex.RUnlock()
+	fake.startFailoverTestMutex.RLock()
+	defer fake.startFailoverTestMutex.RUnlock()
 	fake.updateParamGroupParametersMutex.RLock()
 	defer fake.updateParamGroupParametersMutex.RUnlock()
 	fake.updateReplicationGroupMutex.RLock()

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -67,6 +67,9 @@ type InstanceParameters struct {
 	DailyBackupWindow          string           `json:"daily_backup_window"`
 	MaxMemoryPolicy            string           `json:"maxmemory_policy"`
 	CacheParameters            []CacheParameter `json:"cache_parameters"`
+	ActiveNodes                []string         `json:"active_nodes"`
+	PassiveNodes               []string         `json:"passive_nodes"`
+	AutoFailover               bool             `json:"auto_failover"`
 }
 
 type InstanceDetails struct {
@@ -85,13 +88,14 @@ type Provider interface {
 	UpdateReplicationGroup(ctx context.Context, instanceID string, params UpdateReplicationGroupParameters) error
 	UpdateParamGroupParameters(ctx context.Context, instanceID string, params UpdateParamGroupParameters) error
 	Deprovision(ctx context.Context, instanceID string, params DeprovisionParameters) error
-	GetState(ctx context.Context, instanceID string) (ServiceState, string, error)
+	ProgressState(ctx context.Context, instanceID string, operation string, primaryNode string) (ServiceState, string, error)
 	GetInstanceParameters(ctx context.Context, instanceID string) (InstanceParameters, error)
 	GetInstanceTags(ctx context.Context, instanceID string) (map[string]string, error)
 	GenerateCredentials(ctx context.Context, instanceID, bindingID string) (*Credentials, error)
 	RevokeCredentials(ctx context.Context, instanceID, bindingID string) error
 	DeleteCacheParameterGroup(ctx context.Context, instanceID string) error
 	FindSnapshots(ctx context.Context, instanceID string) ([]SnapshotInfo, error)
+	StartFailoverTest(ctx context.Context, instanceID string) (string, error)
 }
 
 // Credentials are the connection parameters for Redis clients


### PR DESCRIPTION
What
----

Add parameter 'test_failover' that can be passed in as an update option. This option will trigger the redis cluster to perform a primary node failover.

Why
----

We will soon be triggering regular redis updates. Users may experience user application issues where the app doesn't deal with the dns cutover very well. This option will allow them to test how their application deals with a failover.

How
-----

This option when set to true will trigger the following aws actions:

- Disable 'MultiAZ' and 'AutoFailover' for cluster
- Trigger primary node failover
- Enable 'MultiAZ' and 'AutoFailover' for cluster

AWS does provide a test_failover of their own. Sadly this is limited to 5 api calls per day.

Additional Changes
-----

This change also:
- migrates the integration tests from redis 3 to redis 6
- fixes support for non cluster mode snapshot restores
- switches integration tests to use non cluster mode


Who can review
----

One of the old timers