### PR TITLE
Add makefile option to bosh scp built binary to an existing bosh environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 **/coverage/**
+
+# Temporary Build Files
+amd64/*

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,12 @@ integration:
 
 generate-fakes:
 	go generate ./...
+
+.PHONY: build_amd64
+build_amd64:
+	mkdir -p amd64
+	GOOS=linux GOARCH=amd64 go build -o amd64/elasticache-broker
+
+.PHONY: bosh_scp
+bosh_scp: build_amd64
+	./scripts/bosh-scp.sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ AWS_VPC_ID=vpc-deadbeef AWS_SUBNET_CIDR_BLOCK=10.0.16.0/24 \
   go run main.go -config my-config.json
 ```
 
+## Patching an existing bosh environment
+
+If you want to patch an existing bosh environment you can run the following command:
+
+```
+make bosh_scp
+```
+
+This requires an existing bosh session to be established beforehand.
+
 ## Broker configuration
 
 You have to pass in a configuration JSON file with the following format:

--- a/scripts/bosh-scp.sh
+++ b/scripts/bosh-scp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+function run_command() {
+    local command=$1
+    local message=$2
+
+    echo -n "${message}... "
+
+    if ! output=$(bash -c "${command}" 2>&1); then
+        echo -e "failed.\n\n"
+        echo "Command Failed: ${command}"
+        echo ""
+        echo "Output: ${output}"
+        exit 1
+    fi
+    echo "done."
+}
+
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
+command -v bosh >/dev/null 2>&1 || { echo >&2 "bosh is required but it's not installed.  Aborting."; exit 1; }
+command -v cut >/dev/null 2>&1 || { echo >&2 "cut is required but it's not installed.  Aborting."; exit 1; }
+
+
+bosh vms --json | jq -r '.Tables[0].Rows[] | select(.instance|startswith("elasticache_broker/")) | .instance' | while read -r instance; do
+    run_command "bosh ssh ${instance} sudo monit stop elasticache-broker" "stopping elasticache-broker on ${instance}"
+    run_command "bosh scp ./amd64/elasticache-broker ${instance}:/tmp/elasticache-broker" "copying elasticache-broker binary to tmp on ${instance}"
+    run_command "bosh ssh ${instance} sudo mv /tmp/elasticache-broker /var/vcap/packages/elasticache-broker/bin/elasticache-broker" "moving elasticache-broker binary from tmp to packages on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit start elasticache-broker" "starting elasticache-broker on ${instance}"
+done
+


### PR DESCRIPTION
What
----

Add a make bosh_scp target for building and deploying into an existing environment.

Why
----

This allows a more rapid way to deploy and test your changes in an existing environment

How to review
-------------

Test it
