### PR TITLE
BAU - Remove ginkgo CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,21 @@
 ---
 name: CI
 on: pull_request
-
+env:
+  GO_VERSION: 1.20
 jobs:
 
   build:
+    name: Build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      - name: Checkout repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
 
-      - name: Set up Go
+      - name: "Install Go ${{env.GO_VERSION}}"
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.18
+          go-version: "${{env.GO_VERSION}}"
 
-      - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
-
-      - name: Test
-        run: |
-          export GOPATH=$(go env GOPATH)
-          make unit
+      - name: Run tests
+        run: make unit

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 test: unit integration
 
 unit:
-	go run github.com/onsi/ginkgo/v2/ginkgo -r --skip-package=ci
+	go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -r --skip-package=ci
 integration:
-	go run github.com/onsi/ginkgo/v2/ginkgo -timeout=120m -v -r ci/blackbox
+	go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -timeout=120m -v -r ci/blackbox
 
 generate-fakes:
 	go generate ./...


### PR DESCRIPTION
Description:
- Removes the unused ginkgo CLI step in GitHub actions
- Bumps the GitHub action to use 1.20