### PR TITLE
Add tls support to the listener

### DIFF
--- a/broker/config_test.go
+++ b/broker/config_test.go
@@ -93,6 +93,28 @@ var _ = Describe("Config", func() {
 			Expect(config.Validate()).NotTo(Succeed())
 		})
 
+		Describe("tls", func() {
+			It("fails with missing certificate info", func() {
+				config.TLS = &TLSConfig{}
+				config.TLS.Certificate = "invalid"
+				config.TLS.PrivateKey = "invalid"
+				config.TLS.CA = ""
+				err := config.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("TLS Validation failed: Config error: TLS CA required"))
+			})
+
+			It("fails with invalid certificate info", func() {
+				config.TLS = &TLSConfig{}
+				config.TLS.Certificate = "invalid"
+				config.TLS.PrivateKey = "invalid"
+				config.TLS.CA = "invalid"
+				err := config.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("TLS Validation failed: Invalid Certificate and key: tls: failed to find any PEM data in certificate input"))
+			})
+		})
+
 		Context("mapping PlanConfigs to Plans", func() {
 			It("errors if the plan config ID does not map to a plan ID in the catalog", func() {
 				config.PlanConfigs["this-is-not-in-the-catalog"] = PlanConfig{}

--- a/broker/config_test.go
+++ b/broker/config_test.go
@@ -97,18 +97,16 @@ var _ = Describe("Config", func() {
 			It("fails with missing certificate info", func() {
 				config.TLS = &TLSConfig{}
 				config.TLS.Certificate = "invalid"
-				config.TLS.PrivateKey = "invalid"
-				config.TLS.CA = ""
+				config.TLS.PrivateKey = ""
 				err := config.Validate()
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("TLS Validation failed: Config error: TLS CA required"))
+				Expect(err.Error()).To(ContainSubstring("TLS Validation failed: Config error: TLS private key required"))
 			})
 
 			It("fails with invalid certificate info", func() {
 				config.TLS = &TLSConfig{}
 				config.TLS.Certificate = "invalid"
 				config.TLS.PrivateKey = "invalid"
-				config.TLS.CA = "invalid"
 				err := config.Validate()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("TLS Validation failed: Invalid Certificate and key: tls: failed to find any PEM data in certificate input"))

--- a/broker/tls_config.go
+++ b/broker/tls_config.go
@@ -1,0 +1,71 @@
+package broker
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+type TLSConfig struct {
+	Certificate string `json:"certificate"`
+	PrivateKey  string `json:"private_key"`
+	CA          string `json:"ca"`
+}
+
+// GenerateTLSConfig produces a tls.Config structure out of TLSConfig.
+// Aiming to be used while configuring a TLS client or server.
+func (t *TLSConfig) GenerateTLSConfig() (*tls.Config, error) {
+	certificate, err := tls.X509KeyPair([]byte(t.Certificate), []byte(t.PrivateKey))
+	if err != nil {
+		return nil, err
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(&x509.Certificate{
+		Raw: []byte(t.CA),
+	})
+	return &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		RootCAs:      caPool,
+
+		MinVersion:       tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+	}, nil
+}
+
+func (t *TLSConfig) Validate() error {
+	if t.Certificate == "" {
+		return fmt.Errorf("Config error: TLS certificate required")
+	}
+	if t.PrivateKey == "" {
+		return fmt.Errorf("Config error: TLS private key required")
+	}
+	if t.CA == "" {
+		return fmt.Errorf("Config error: TLS CA required")
+	}
+
+	_, err := tls.X509KeyPair([]byte(t.Certificate), []byte(t.PrivateKey))
+	if err != nil {
+		return fmt.Errorf("Invalid Certificate and key: %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(t.CA))
+	if block == nil {
+		return fmt.Errorf("Failed to decode CA certificate")
+	}
+	_, err = x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("Failed to parse CA certificate: %v", err)
+	}
+
+	return nil
+}

--- a/broker/tls_config.go
+++ b/broker/tls_config.go
@@ -2,15 +2,12 @@ package broker
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 )
 
 type TLSConfig struct {
 	Certificate string `json:"certificate"`
 	PrivateKey  string `json:"private_key"`
-	CA          string `json:"ca"`
 }
 
 // GenerateTLSConfig produces a tls.Config structure out of TLSConfig.
@@ -21,13 +18,8 @@ func (t *TLSConfig) GenerateTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 
-	caPool := x509.NewCertPool()
-	caPool.AddCert(&x509.Certificate{
-		Raw: []byte(t.CA),
-	})
 	return &tls.Config{
 		Certificates: []tls.Certificate{certificate},
-		RootCAs:      caPool,
 
 		MinVersion:       tls.VersionTLS12,
 		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
@@ -49,22 +41,10 @@ func (t *TLSConfig) Validate() error {
 	if t.PrivateKey == "" {
 		return fmt.Errorf("Config error: TLS private key required")
 	}
-	if t.CA == "" {
-		return fmt.Errorf("Config error: TLS CA required")
-	}
 
 	_, err := tls.X509KeyPair([]byte(t.Certificate), []byte(t.PrivateKey))
 	if err != nil {
 		return fmt.Errorf("Invalid Certificate and key: %v", err)
-	}
-
-	block, _ := pem.Decode([]byte(t.CA))
-	if block == nil {
-		return fmt.Errorf("Failed to decode CA certificate")
-	}
-	_, err = x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return fmt.Errorf("Failed to parse CA certificate: %v", err)
 	}
 
 	return nil

--- a/broker/tls_config_test.go
+++ b/broker/tls_config_test.go
@@ -1,0 +1,102 @@
+package broker_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/alphagov/paas-elasticache-broker/broker"
+	. "github.com/alphagov/paas-elasticache-broker/test"
+)
+
+var _ = Describe("TLSConfig", Ordered, func() {
+	var (
+		certPEM         []byte
+		keyPEM          []byte
+		caPEM           []byte
+		tlsConfig       *TLSConfig
+		generatedConfig *tls.Config
+		err             error
+	)
+
+	BeforeAll(func() {
+		// Generate test certificates and keys
+		certPEM, keyPEM, caPEM, err = GenerateTestCert()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+
+		tlsConfig = &TLSConfig{
+			Certificate: string(certPEM),
+			PrivateKey:  string(keyPEM),
+			CA:          string(caPEM),
+		}
+	})
+
+	Describe("GenerateTLSConfig", func() {
+		BeforeEach(func() {
+			// Generate a tls.Config structure out of the TLSConfig instance
+			generatedConfig, err = tlsConfig.GenerateTLSConfig()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should generate a valid tls.Config structure", func() {
+			Expect(len(generatedConfig.Certificates)).To(Equal(1))
+			Expect(generatedConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+			Expect(generatedConfig.CipherSuites).To(Equal([]uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			}))
+
+			cert, err := x509.ParseCertificate(generatedConfig.Certificates[0].Certificate[0])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cert.Subject.CommonName).To(Equal("example.com"))
+
+			intermediateCert, err := x509.ParseCertificate(generatedConfig.Certificates[0].Certificate[1])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(intermediateCert.Subject.CommonName).To(Equal("Intermediate CA"))
+		})
+	})
+
+	Describe("validate", func() {
+		It("should return an error if Certificate is empty", func() {
+			tlsConfig.Certificate = ""
+			err = tlsConfig.Validate()
+			Expect(err).To(MatchError("Config error: TLS certificate required"))
+		})
+
+		It("should return an error if PrivateKey is empty", func() {
+			tlsConfig.PrivateKey = ""
+			err = tlsConfig.Validate()
+			Expect(err).To(MatchError("Config error: TLS private key required"))
+		})
+
+		It("should return an error if CA is empty", func() {
+			tlsConfig.CA = ""
+			err = tlsConfig.Validate()
+			Expect(err).To(MatchError("Config error: TLS CA required"))
+		})
+
+		It("should return an error if Certificate is invalid", func() {
+			tlsConfig.Certificate = "invalid"
+			err = tlsConfig.Validate()
+			Expect(err).To(MatchError("Invalid Certificate and key: tls: failed to find any PEM data in certificate input"))
+		})
+
+		It("should return an error if CA is invalid", func() {
+			tlsConfig.CA = "invalid"
+			err = tlsConfig.Validate()
+			Expect(err).To(MatchError("Failed to decode CA certificate"))
+		})
+
+		It("should not return an error if all fields are present", func() {
+			err = tlsConfig.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/broker/tls_config_test.go
+++ b/broker/tls_config_test.go
@@ -15,7 +15,6 @@ var _ = Describe("TLSConfig", Ordered, func() {
 	var (
 		certPEM         []byte
 		keyPEM          []byte
-		caPEM           []byte
 		tlsConfig       *TLSConfig
 		generatedConfig *tls.Config
 		err             error
@@ -23,7 +22,7 @@ var _ = Describe("TLSConfig", Ordered, func() {
 
 	BeforeAll(func() {
 		// Generate test certificates and keys
-		certPEM, keyPEM, caPEM, err = GenerateTestCert()
+		certPEM, keyPEM, _, err = GenerateTestCert()
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -32,7 +31,6 @@ var _ = Describe("TLSConfig", Ordered, func() {
 		tlsConfig = &TLSConfig{
 			Certificate: string(certPEM),
 			PrivateKey:  string(keyPEM),
-			CA:          string(caPEM),
 		}
 	})
 
@@ -76,22 +74,10 @@ var _ = Describe("TLSConfig", Ordered, func() {
 			Expect(err).To(MatchError("Config error: TLS private key required"))
 		})
 
-		It("should return an error if CA is empty", func() {
-			tlsConfig.CA = ""
-			err = tlsConfig.Validate()
-			Expect(err).To(MatchError("Config error: TLS CA required"))
-		})
-
 		It("should return an error if Certificate is invalid", func() {
 			tlsConfig.Certificate = "invalid"
 			err = tlsConfig.Validate()
 			Expect(err).To(MatchError("Invalid Certificate and key: tls: failed to find any PEM data in certificate input"))
-		})
-
-		It("should return an error if CA is invalid", func() {
-			tlsConfig.CA = "invalid"
-			err = tlsConfig.Validate()
-			Expect(err).To(MatchError("Failed to decode CA certificate"))
 		})
 
 		It("should not return an error if all fields are present", func() {

--- a/ci/blackbox/integration_suite_test.go
+++ b/ci/blackbox/integration_suite_test.go
@@ -49,7 +49,7 @@ func TestSuite(t *testing.T) {
 		certPEM, keyPEM, caPEM, err := test.GenerateTestCert()
 		Expect(err).NotTo(HaveOccurred())
 
-		configBase, err := test.SetTLSConfigOptions("./config.json", certPEM, keyPEM, caPEM)
+		configBase, err := test.SetTLSConfigOptions("./config.json", certPEM, keyPEM)
 		defer os.Remove(configBase)
 
 		originalConfig, err := broker.LoadConfig(configBase)

--- a/ci/blackbox/integration_suite_test.go
+++ b/ci/blackbox/integration_suite_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/alphagov/paas-elasticache-broker/broker"
 	. "github.com/alphagov/paas-elasticache-broker/ci/helpers"
+	test "github.com/alphagov/paas-elasticache-broker/test"
 )
 
 const clusterNamePrefix = "cf-broker-test"
@@ -45,7 +46,13 @@ func TestSuite(t *testing.T) {
 
 		fmt.Fprintln(GinkgoWriter, os.Environ())
 
-		originalConfig, err := broker.LoadConfig("./config.json")
+		certPEM, keyPEM, caPEM, err := test.GenerateTestCert()
+		Expect(err).NotTo(HaveOccurred())
+
+		configBase, err := test.SetTLSConfigOptions("./config.json", certPEM, keyPEM, caPEM)
+		defer os.Remove(configBase)
+
+		originalConfig, err := broker.LoadConfig(configBase)
 		Expect(err).NotTo(HaveOccurred())
 
 		awsSession = session.Must(session.NewSession(&aws.Config{
@@ -90,7 +97,7 @@ func TestSuite(t *testing.T) {
 		Eventually(elastiCacheBrokerSession, 10*time.Second).
 			Should(gbytes.Say(fmt.Sprintf("ElastiCache Service Broker started on port %d", elastiCacheBrokerPort)))
 
-		elastiCacheBrokerUrl = fmt.Sprintf("http://localhost:%d", elastiCacheBrokerPort)
+		elastiCacheBrokerUrl = fmt.Sprintf("https://localhost:%d", elastiCacheBrokerPort)
 
 		brokerAPIClient = NewBrokerAPIClient(
 			elastiCacheBrokerUrl,
@@ -98,6 +105,7 @@ func TestSuite(t *testing.T) {
 			elastiCacheBrokerConfig.Password,
 			"test-organization-id",
 			"space-id",
+			caPEM,
 		)
 	})
 
@@ -113,7 +121,9 @@ func TestSuite(t *testing.T) {
 		if elastiCacheSubnetGroupName != nil {
 			Expect(DestroySubnetGroup(elastiCacheSubnetGroupName, awsSession)).To(Succeed())
 		}
-		elastiCacheBrokerSession.Kill()
+		if elastiCacheBrokerSession != nil {
+			elastiCacheBrokerSession.Kill()
+		}
 	})
 
 	RegisterFailHandler(Fail)

--- a/main_test.go
+++ b/main_test.go
@@ -65,7 +65,7 @@ var _ = Describe("broker command", Ordered, func() {
 			certPEM, keyPEM, caPEM, err := test.GenerateTestCert()
 			Expect(err).NotTo(HaveOccurred())
 
-			filename, err := test.SetTLSConfigOptions("./test/fixtures/config.json", certPEM, keyPEM, caPEM)
+			filename, err := test.SetTLSConfigOptions("./test/fixtures/config.json", certPEM, keyPEM)
 			Expect(err).NotTo(HaveOccurred())
 			defer os.Remove(filename)
 
@@ -88,9 +88,6 @@ var _ = Describe("broker command", Ordered, func() {
 			httpClient := &http.Client{
 				Transport: transport,
 			}
-
-			// sleep 900 seconds
-			time.Sleep(900 * time.Second)
 
 			// Wait for the server to start
 			Eventually(func() error {

--- a/main_test.go
+++ b/main_test.go
@@ -1,27 +1,109 @@
 package main_test
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
 	"os/exec"
+	"time"
 
+	"github.com/alphagov/paas-elasticache-broker/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("broker command", Ordered, func() {
+	var (
+		path    string
+		command string
+		err     error
+	)
+
+	BeforeAll(func() {
+		path, err = gexec.Build(".")
+		Expect(err).NotTo(HaveOccurred())
+		command = path + "/paas-elasticache-broker"
+	})
+
 	AfterAll(func() {
 		gexec.CleanupBuildArtifacts()
 	})
 
 	It("exits nonzero when given a path to a nonexistent config file", func() {
-		path, err := gexec.Build("github.com/alphagov/paas-elasticache-broker")
-		Expect(err).NotTo(HaveOccurred())
-
-		cmd := exec.Command(path, "-config", "anonexistentconfigfile")
+		cmd := exec.Command(command, "-config", "anonexistentconfigfile")
 		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
 		session.Wait()
 		Expect(session).To(gexec.Exit(1))
+	})
+
+	Describe("when given a valid config file", func() {
+
+		It("starts the http server", func() {
+			cmd := exec.Command(command, "-config", "./test/fixtures/config.json", "-port", "8080")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for the server to start
+			Eventually(func() error {
+				_, err := http.Get("http://localhost:8080/healthcheck")
+				return err
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			// Stop the server
+			session.Interrupt()
+			Eventually(session).Should(gexec.Exit())
+
+			// Check the exit code
+			Expect(session.ExitCode()).To(Equal(130))
+		})
+
+		It("starts the https server", func() {
+			certPEM, keyPEM, caPEM, err := test.GenerateTestCert()
+			Expect(err).NotTo(HaveOccurred())
+
+			filename, err := test.SetTLSConfigOptions("./test/fixtures/config.json", certPEM, keyPEM, caPEM)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(filename)
+
+			cmd := exec.Command(command, "-config", filename, "-port", "8080")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			certPool := x509.NewCertPool()
+			certPool.AppendCertsFromPEM([]byte(caPEM))
+
+			// Create a custom transport with the certificate pool
+			transport := &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:    certPool,
+					ServerName: "example.com",
+				},
+			}
+
+			// Create a http client with the custom transport
+			httpClient := &http.Client{
+				Transport: transport,
+			}
+
+			// sleep 900 seconds
+			time.Sleep(900 * time.Second)
+
+			// Wait for the server to start
+			Eventually(func() error {
+				_, err := httpClient.Get("https://localhost:8080/healthcheck")
+				return err
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			// Stop the server
+			session.Interrupt()
+			Eventually(session).Should(gexec.Exit())
+
+			// Check the exit code
+			Expect(session.ExitCode()).To(Equal(130))
+		})
 	})
 })

--- a/scripts/run-broker-tls.sh
+++ b/scripts/run-broker-tls.sh
@@ -35,6 +35,6 @@ echo "TLS Certificates Generated in ${_tmp_dir}"
 echo "Example curl command: curl --cacert ${_tmp_dir}/CAcert.pem https://127.0.0.1:3000"
 
 jq \
-    '.tls.certificate = "'"${cert_value}"'" | .tls.private_key = "'"${key_value}"'" | .tls.ca = "'"${ca_cert_value}"'"' \
+    '.tls.certificate = "'"${cert_value}"'" | .tls.private_key = "'"${key_value}"'"' \
     "${SCRIPT_DIR}/../test/fixtures/config.json" > "${_tmp_dir}/config.json"
 go run main.go --config "${_tmp_dir}/config.json"

--- a/scripts/run-broker-tls.sh
+++ b/scripts/run-broker-tls.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+_tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${_tmp_dir}"' EXIT
+
+pushd "${_tmp_dir}" > /dev/null
+    echo "Generating TLS Certificates"
+    # Generate the CA Key and Certificate for signing Client Certs
+    openssl req -x509 -newkey rsa:1024 -nodes \
+        -keyout CAkey.pem -out CAcert.pem \
+        -sha256 -days 3650 -nodes \
+        -subj "/C=UK/ST=London/L=London/O=PAASDEV/CN=broker-ca.local" &> /dev/null
+
+    # Generate the Server Key, and CSR and sign with the CA Certificate
+    openssl req -new -newkey rsa:1024 -nodes \
+        -keyout key.pem -out req.pem \
+        -subj "/C=UK/ST=London/L=London/O=PAASDEV/CN=broker.local" &> /dev/null
+    openssl x509 -req \
+        -in req.pem -CA CAcert.pem -CAkey CAkey.pem \
+        -extfile <(printf "subjectAltName=IP:127.0.0.1") \
+        -CAcreateserial -out cert.pem -days 30 -sha256 #&> /dev/null
+
+    # rm CAkey.pem req.pem
+
+    cert_value="$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g' "cert.pem")"
+    key_value="$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g' "key.pem")"
+    ca_cert_value="$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g' "CAcert.pem")"
+popd > /dev/null
+
+echo "TLS Certificates Generated in ${_tmp_dir}"
+echo "Example curl command: curl --cacert ${_tmp_dir}/CAcert.pem https://127.0.0.1:3000"
+
+jq \
+    '.tls.certificate = "'"${cert_value}"'" | .tls.private_key = "'"${key_value}"'" | .tls.ca = "'"${ca_cert_value}"'"' \
+    "${SCRIPT_DIR}/../test/fixtures/config.json" > "${_tmp_dir}/config.json"
+go run main.go --config "${_tmp_dir}/config.json"

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,0 +1,19 @@
+{
+	"cluster_name_prefix": "cf-broker-test",
+	"cache_subnet_group_name": "test-subnet",
+	"vpc_security_group_ids": [
+		"test-security-group-id"
+	],
+	"region": "eu-west-1",
+	"log_level": "DEBUG",
+	"username": "username",
+	"password": "password",
+	"broker_name": "elasticache-unit-test",
+	"secrets_manager_path": "elasticache-broker-test",
+	"kms_key_id": "alias/elasticache-broker-test",
+	"catalog": {
+		"services": []
+	},
+	"plan_configs": {},
+	"host": "127.0.0.1"
+}

--- a/test/tls_helpers.go
+++ b/test/tls_helpers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alphagov/paas-elasticache-broker/broker"
 )
 
-func SetTLSConfigOptions(configFile string, certficiate []byte, key []byte, ca []byte) (string, error) {
+func SetTLSConfigOptions(configFile string, certficiate []byte, key []byte) (string, error) {
 
 	data, err := os.ReadFile(configFile)
 	if err != nil {
@@ -31,7 +31,6 @@ func SetTLSConfigOptions(configFile string, certficiate []byte, key []byte, ca [
 	config.TLS = &broker.TLSConfig{}
 	config.TLS.Certificate = string(certficiate)
 	config.TLS.PrivateKey = string(key)
-	config.TLS.CA = string(ca)
 
 	data, err = json.Marshal(config)
 	if err != nil {

--- a/test/tls_helpers.go
+++ b/test/tls_helpers.go
@@ -1,0 +1,135 @@
+package test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/alphagov/paas-elasticache-broker/broker"
+)
+
+func SetTLSConfigOptions(configFile string, certficiate []byte, key []byte, ca []byte) (string, error) {
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read config file: %v", err)
+	}
+
+	var config broker.Config
+	err = json.Unmarshal(data, &config)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal json file: %v", err)
+	}
+
+	config.TLS = &broker.TLSConfig{}
+	config.TLS.Certificate = string(certficiate)
+	config.TLS.PrivateKey = string(key)
+	config.TLS.CA = string(ca)
+
+	data, err = json.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal json file: %v", err)
+	}
+
+	file, err := os.CreateTemp("", "config")
+	if err != nil {
+		return "", fmt.Errorf("Failed to create temp file: %v", err)
+	}
+	defer file.Close()
+
+	_, err = file.Write(data)
+	if err != nil {
+		return "", fmt.Errorf("Failed to write to temp file: %v", err)
+	}
+
+	return file.Name(), nil
+}
+
+func GenerateTestCert() ([]byte, []byte, []byte, error) {
+	// Generate a new RSA private key for the root CA
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to generate RSA key for root CA: %v", err)
+	}
+
+	// Generate a new self-signed X.509 certificate for the root CA
+	rootTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "Root CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(100, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	rootCertDER, err := x509.CreateCertificate(rand.Reader, &rootTemplate, &rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to create X.509 certificate for root CA: %v", err)
+	}
+
+	// Generate a new RSA private key for the intermediate CA
+	intermediateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to generate RSA key for intermediate CA: %v", err)
+	}
+
+	// Generate a new self-signed X.509 certificate for the intermediate CA
+	intermediateTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "Intermediate CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(100, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	intermediateCertDER, err := x509.CreateCertificate(rand.Reader, &intermediateTemplate, &rootTemplate, &intermediateKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to create X.509 certificate for intermediate CA: %v", err)
+	}
+
+	// Generate a new RSA private key for the certificate
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to generate RSA key for certificate: %v", err)
+	}
+
+	// Generate a new X.509 certificate signed by the intermediate CA
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject: pkix.Name{
+			CommonName: "example.com",
+		},
+		DNSNames:              []string{"example.com"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(100, 0, 0),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &intermediateTemplate, &certKey.PublicKey, intermediateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to create X.509 certificate signed by intermediate CA: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	intermediatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: intermediateCertDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(certKey)})
+	rootCAPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootCertDER})
+	certChainPEM := append(certPEM, intermediatePEM...)
+
+	return certChainPEM, keyPEM, rootCAPEM, nil
+}


### PR DESCRIPTION
What
----

Add tls support to the elasticache broker.

Why
----

We need to ensure traffic is encrypted between the load balancer and the elasticache broker.